### PR TITLE
Modify the standard's manual to be used by drone.

### DIFF
--- a/include/rm_manual/chassis_gimbal_manual.h
+++ b/include/rm_manual/chassis_gimbal_manual.h
@@ -64,6 +64,8 @@ protected:
   double gyro_move_reduction_{ 1. };
   double gyro_rotate_reduction_{ 1. };
 
+  bool check_drone;
+
   InputEvent chassis_power_on_event_, gimbal_power_on_event_, w_event_, s_event_, a_event_, d_event_, mouse_mid_event_;
 };
 }  // namespace rm_manual

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -39,30 +39,30 @@ ChassisGimbalManual::ChassisGimbalManual(ros::NodeHandle& nh) : ManualBase(nh)
 
 void ChassisGimbalManual::sendCommand(const ros::Time& time)
 {
-  chassis_cmd_sender_->sendCommand(time);
-  vel_cmd_sender_->sendCommand(time);
+//  chassis_cmd_sender_->sendCommand(time);
+//  vel_cmd_sender_->sendCommand(time);
   gimbal_cmd_sender_->sendCommand(time);
 }
 
 void ChassisGimbalManual::updateRc()
 {
   ManualBase::updateRc();
-  if (std::abs(data_.dbus_data_.wheel) > 0.01)
-  {
-    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::GYRO);
-  }
-  else
-    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-  vel_cmd_sender_->setAngularZVel(
-      (std::abs(data_.dbus_data_.ch_r_y) > 0.01 || std::abs(data_.dbus_data_.ch_r_x) > 0.01) ?
-          data_.dbus_data_.wheel * gyro_rotate_reduction_ :
-          data_.dbus_data_.wheel);
-  vel_cmd_sender_->setLinearXVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
-                                     data_.dbus_data_.ch_r_y * gyro_move_reduction_ :
-                                     data_.dbus_data_.ch_r_y);
-  vel_cmd_sender_->setLinearYVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
-                                     -data_.dbus_data_.ch_r_x * gyro_move_reduction_ :
-                                     -data_.dbus_data_.ch_r_x);
+//  if (std::abs(data_.dbus_data_.wheel) > 0.01)
+//  {
+//    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::GYRO);
+//  }
+//  else
+//    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
+//  vel_cmd_sender_->setAngularZVel(
+//      (std::abs(data_.dbus_data_.ch_r_y) > 0.01 || std::abs(data_.dbus_data_.ch_r_x) > 0.01) ?
+//          data_.dbus_data_.wheel * gyro_rotate_reduction_ :
+//          data_.dbus_data_.wheel);
+//  vel_cmd_sender_->setLinearXVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
+//                                     data_.dbus_data_.ch_r_y * gyro_move_reduction_ :
+//                                     data_.dbus_data_.ch_r_y);
+//  vel_cmd_sender_->setLinearYVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
+//                                     -data_.dbus_data_.ch_r_x * gyro_move_reduction_ :
+//                                     -data_.dbus_data_.ch_r_x);
   gimbal_cmd_sender_->setRate(-data_.dbus_data_.ch_l_x, -data_.dbus_data_.ch_l_y);
 }
 
@@ -75,7 +75,7 @@ void ChassisGimbalManual::updatePc()
 void ChassisGimbalManual::checkReferee()
 {
   ManualBase::checkReferee();
-  chassis_power_on_event_.update(data_.referee_.referee_data_.game_robot_status_.mains_power_chassis_output_);
+//  chassis_power_on_event_.update(data_.referee_.referee_data_.game_robot_status_.mains_power_chassis_output_);
   gimbal_power_on_event_.update(data_.referee_.referee_data_.game_robot_status_.mains_power_gimbal_output_);
 }
 
@@ -127,16 +127,16 @@ void ChassisGimbalManual::drawUi(const ros::Time& time)
 void ChassisGimbalManual::remoteControlTurnOff()
 {
   ManualBase::remoteControlTurnOff();
-  vel_cmd_sender_->setZero();
-  chassis_cmd_sender_->setZero();
+//  vel_cmd_sender_->setZero();
+//  chassis_cmd_sender_->setZero();
   gimbal_cmd_sender_->setZero();
 }
 
 void ChassisGimbalManual::rightSwitchDownRise()
 {
   ManualBase::rightSwitchDownRise();
-  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-  vel_cmd_sender_->setZero();
+//  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
+//  vel_cmd_sender_->setZero();
   gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
   gimbal_cmd_sender_->setZero();
 }
@@ -144,15 +144,15 @@ void ChassisGimbalManual::rightSwitchDownRise()
 void ChassisGimbalManual::rightSwitchMidRise()
 {
   ManualBase::rightSwitchMidRise();
-  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
+//  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
   gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
 }
 
 void ChassisGimbalManual::rightSwitchUpRise()
 {
   ManualBase::rightSwitchUpRise();
-  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-  vel_cmd_sender_->setZero();
+//  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
+//  vel_cmd_sender_->setZero();
   gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
   trigger_change_ui_->add();
   time_change_ui_->add();
@@ -161,7 +161,7 @@ void ChassisGimbalManual::rightSwitchUpRise()
 
 void ChassisGimbalManual::leftSwitchMidFall()
 {
-  chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
+//  chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
 }
 
 void ChassisGimbalManual::leftSwitchDownRise()

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -23,6 +23,8 @@ ChassisGimbalManual::ChassisGimbalManual(ros::NodeHandle& nh) : ManualBase(nh)
   time_change_ui_ = new TimeChangeUi(ui_nh, data_);
   flash_ui_ = new FlashUi(ui_nh, data_);
   fixed_ui_ = new FixedUi(ui_nh, data_);
+  ros::NodeHandle check_nh("~");
+  check_drone = getParam(check_nh, "check_drone", (bool) false);
 
   chassis_power_on_event_.setRising(boost::bind(&ChassisGimbalManual::chassisOutputOn, this));
   gimbal_power_on_event_.setRising(boost::bind(&ChassisGimbalManual::gimbalOutputOn, this));
@@ -39,30 +41,33 @@ ChassisGimbalManual::ChassisGimbalManual(ros::NodeHandle& nh) : ManualBase(nh)
 
 void ChassisGimbalManual::sendCommand(const ros::Time& time)
 {
-//  chassis_cmd_sender_->sendCommand(time);
-//  vel_cmd_sender_->sendCommand(time);
+    if(check_drone == false)
+    {
+        chassis_cmd_sender_->sendCommand(time);
+        vel_cmd_sender_->sendCommand(time);
+    }
   gimbal_cmd_sender_->sendCommand(time);
 }
 
 void ChassisGimbalManual::updateRc()
 {
   ManualBase::updateRc();
-//  if (std::abs(data_.dbus_data_.wheel) > 0.01)
-//  {
-//    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::GYRO);
-//  }
-//  else
-//    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-//  vel_cmd_sender_->setAngularZVel(
-//      (std::abs(data_.dbus_data_.ch_r_y) > 0.01 || std::abs(data_.dbus_data_.ch_r_x) > 0.01) ?
-//          data_.dbus_data_.wheel * gyro_rotate_reduction_ :
-//          data_.dbus_data_.wheel);
-//  vel_cmd_sender_->setLinearXVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
-//                                     data_.dbus_data_.ch_r_y * gyro_move_reduction_ :
-//                                     data_.dbus_data_.ch_r_y);
-//  vel_cmd_sender_->setLinearYVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
-//                                     -data_.dbus_data_.ch_r_x * gyro_move_reduction_ :
-//                                     -data_.dbus_data_.ch_r_x);
+  if (std::abs(data_.dbus_data_.wheel) > 0.01)
+  {
+    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::GYRO);
+  }
+  else
+    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
+  vel_cmd_sender_->setAngularZVel(
+      (std::abs(data_.dbus_data_.ch_r_y) > 0.01 || std::abs(data_.dbus_data_.ch_r_x) > 0.01) ?
+          data_.dbus_data_.wheel * gyro_rotate_reduction_ :
+          data_.dbus_data_.wheel);
+  vel_cmd_sender_->setLinearXVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
+                                     data_.dbus_data_.ch_r_y * gyro_move_reduction_ :
+                                     data_.dbus_data_.ch_r_y);
+  vel_cmd_sender_->setLinearYVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
+                                     -data_.dbus_data_.ch_r_x * gyro_move_reduction_ :
+                                     -data_.dbus_data_.ch_r_x);
   gimbal_cmd_sender_->setRate(-data_.dbus_data_.ch_l_x, -data_.dbus_data_.ch_l_y);
 }
 
@@ -75,7 +80,7 @@ void ChassisGimbalManual::updatePc()
 void ChassisGimbalManual::checkReferee()
 {
   ManualBase::checkReferee();
-//  chassis_power_on_event_.update(data_.referee_.referee_data_.game_robot_status_.mains_power_chassis_output_);
+  chassis_power_on_event_.update(data_.referee_.referee_data_.game_robot_status_.mains_power_chassis_output_);
   gimbal_power_on_event_.update(data_.referee_.referee_data_.game_robot_status_.mains_power_gimbal_output_);
 }
 
@@ -127,16 +132,16 @@ void ChassisGimbalManual::drawUi(const ros::Time& time)
 void ChassisGimbalManual::remoteControlTurnOff()
 {
   ManualBase::remoteControlTurnOff();
-//  vel_cmd_sender_->setZero();
-//  chassis_cmd_sender_->setZero();
+  vel_cmd_sender_->setZero();
+  chassis_cmd_sender_->setZero();
   gimbal_cmd_sender_->setZero();
 }
 
 void ChassisGimbalManual::rightSwitchDownRise()
 {
   ManualBase::rightSwitchDownRise();
-//  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-//  vel_cmd_sender_->setZero();
+  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
+  vel_cmd_sender_->setZero();
   gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
   gimbal_cmd_sender_->setZero();
 }
@@ -144,15 +149,15 @@ void ChassisGimbalManual::rightSwitchDownRise()
 void ChassisGimbalManual::rightSwitchMidRise()
 {
   ManualBase::rightSwitchMidRise();
-//  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
+  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
   gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
 }
 
 void ChassisGimbalManual::rightSwitchUpRise()
 {
   ManualBase::rightSwitchUpRise();
-//  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-//  vel_cmd_sender_->setZero();
+  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
+  vel_cmd_sender_->setZero();
   gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
   trigger_change_ui_->add();
   time_change_ui_->add();
@@ -161,7 +166,7 @@ void ChassisGimbalManual::rightSwitchUpRise()
 
 void ChassisGimbalManual::leftSwitchMidFall()
 {
-//  chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
+  chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
 }
 
 void ChassisGimbalManual::leftSwitchDownRise()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,8 @@ int main(int argc, char** argv)
     manual_control = new rm_manual::ChassisGimbalShooterManual(nh);
   else if (robot == "engineer")
     manual_control = new rm_manual::EngineerManual(nh);
+  else if (robot == "drone")
+      manual_control = new rm_manual::ChassisGimbalShooterCoverManual(nh);
   else
   {
     ROS_ERROR("no robot type ");


### PR DESCRIPTION
步兵的manual在空中上跑不了的原因是缺少底盘部分的参数，导致底盘在sendcommand的时候涉及到给vector赋空值，所以新加一个参数用于判断robot_type是否为空中来滤掉底盘的sendcommand。