### PR TITLE
Low speed mode 

### DIFF
--- a/include/rm_manual/chassis_gimbal_manual.h
+++ b/include/rm_manual/chassis_gimbal_manual.h
@@ -31,7 +31,6 @@ protected:
   void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data) override;
   void capacityDataCallback(const rm_msgs::CapacityData ::ConstPtr& data) override;
   void trackCallback(const rm_msgs::TrackData::ConstPtr& data) override;
-  double judgeMode(double scale);
   virtual void wPress()
   {
     x_scale_ = x_scale_ >= 1.0 ? 1.0 : x_scale_ + 1.0;

--- a/include/rm_manual/chassis_gimbal_manual.h
+++ b/include/rm_manual/chassis_gimbal_manual.h
@@ -31,6 +31,7 @@ protected:
   void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data) override;
   void capacityDataCallback(const rm_msgs::CapacityData ::ConstPtr& data) override;
   void trackCallback(const rm_msgs::TrackData::ConstPtr& data) override;
+  double judgeMode(double scale);
   virtual void wPress()
   {
     x_scale_ = x_scale_ >= 1.0 ? 1.0 : x_scale_ + 1.0;
@@ -60,11 +61,13 @@ protected:
   rm_common::Vel2DCommandSender* vel_cmd_sender_{};
   rm_common::GimbalCommandSender* gimbal_cmd_sender_{};
   rm_common::ChassisCommandSender* chassis_cmd_sender_{};
+
   double x_scale_{}, y_scale_{};
+  bool speed_change_mode_{ 0 };
+  double speed_change_scale_{ 1. };
   double gimbal_scale_{ 1. };
   double gyro_move_reduction_{ 1. };
   double gyro_rotate_reduction_{ 1. };
-
   InputEvent chassis_power_on_event_, gimbal_power_on_event_, w_event_, s_event_, a_event_, d_event_;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -64,10 +64,6 @@ private:
   void ctrlRPress();
   void shiftPressing();
   void shiftRelease();
-  void shiftQPress();
-  void shiftQRelease();
-  void shiftEPress();
-  void shiftERelease();
   void shiftZPress();
   void shiftXPress();
   void shiftCPress();

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -10,6 +10,8 @@ ChassisGimbalManual::ChassisGimbalManual(ros::NodeHandle& nh, ros::NodeHandle& n
 {
   ros::NodeHandle chassis_nh(nh, "chassis");
   chassis_cmd_sender_ = new rm_common::ChassisCommandSender(chassis_nh);
+  if (!chassis_nh.getParam("speed_change_scale", speed_change_scale_))
+    speed_change_scale_ = 1.;
   ros::NodeHandle vel_nh(nh, "vel");
   vel_cmd_sender_ = new rm_common::Vel2DCommandSender(vel_nh);
   if (!vel_nh.getParam("gyro_move_reduction", gyro_move_reduction_))
@@ -75,10 +77,10 @@ void ChassisGimbalManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_
   ManualBase::checkKeyboard(dbus_data);
   if (robot_id_ == rm_msgs::GameRobotStatus::RED_ENGINEER || robot_id_ == rm_msgs::GameRobotStatus::BLUE_ENGINEER)
   {
-    w_event_.update((!dbus_data->key_ctrl) && (!dbus_data->key_shift) && dbus_data->key_w);
-    s_event_.update((!dbus_data->key_ctrl) && (!dbus_data->key_shift) && dbus_data->key_s);
-    a_event_.update((!dbus_data->key_ctrl) && (!dbus_data->key_shift) && dbus_data->key_a);
-    d_event_.update((!dbus_data->key_ctrl) && (!dbus_data->key_shift) && dbus_data->key_d);
+    w_event_.update((!dbus_data->key_ctrl) && dbus_data->key_w);
+    s_event_.update((!dbus_data->key_ctrl) && dbus_data->key_s);
+    a_event_.update((!dbus_data->key_ctrl) && dbus_data->key_a);
+    d_event_.update((!dbus_data->key_ctrl) && dbus_data->key_d);
   }
   else
   {
@@ -173,10 +175,19 @@ void ChassisGimbalManual::leftSwitchDownRise()
   gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
 }
 
+double ChassisGimbalManual::judgeMode(double scale)
+{
+  if (speed_change_mode_)
+    scale *= speed_change_scale_;
+  return scale;
+}
+
 void ChassisGimbalManual::wPressing()
 {
-  vel_cmd_sender_->setLinearXVel(
-      chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ? x_scale_ * gyro_move_reduction_ : x_scale_);
+  double final_x_scale = judgeMode(x_scale_);
+  vel_cmd_sender_->setLinearXVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
+                                     final_x_scale * gyro_move_reduction_ :
+                                     final_x_scale);
   vel_cmd_sender_->setAngularZVel(
       chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ? gyro_rotate_reduction_ : 0);
 }
@@ -190,8 +201,10 @@ void ChassisGimbalManual::wRelease()
 
 void ChassisGimbalManual::sPressing()
 {
-  vel_cmd_sender_->setLinearXVel(
-      chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ? x_scale_ * gyro_move_reduction_ : x_scale_);
+  double final_x_scale = judgeMode(x_scale_);
+  vel_cmd_sender_->setLinearXVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
+                                     final_x_scale * gyro_move_reduction_ :
+                                     final_x_scale);
   vel_cmd_sender_->setAngularZVel(
       chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ? gyro_rotate_reduction_ : 0);
 }
@@ -205,8 +218,10 @@ void ChassisGimbalManual::sRelease()
 
 void ChassisGimbalManual::aPressing()
 {
-  vel_cmd_sender_->setLinearYVel(
-      chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ? y_scale_ * gyro_move_reduction_ : y_scale_);
+  double final_y_scale = judgeMode(y_scale_);
+  vel_cmd_sender_->setLinearYVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
+                                     final_y_scale * gyro_move_reduction_ :
+                                     final_y_scale);
   vel_cmd_sender_->setAngularZVel(
       chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ? gyro_rotate_reduction_ : 0);
 }
@@ -220,8 +235,10 @@ void ChassisGimbalManual::aRelease()
 
 void ChassisGimbalManual::dPressing()
 {
-  vel_cmd_sender_->setLinearYVel(
-      chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ? y_scale_ * gyro_move_reduction_ : y_scale_);
+  double final_y_scale = judgeMode(y_scale_);
+  vel_cmd_sender_->setLinearYVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
+                                     final_y_scale * gyro_move_reduction_ :
+                                     final_y_scale);
   vel_cmd_sender_->setAngularZVel(
       chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ? gyro_rotate_reduction_ : 0);
 }

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -175,16 +175,11 @@ void ChassisGimbalManual::leftSwitchDownRise()
   gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
 }
 
-double ChassisGimbalManual::judgeMode(double scale)
-{
-  if (speed_change_mode_)
-    scale *= speed_change_scale_;
-  return scale;
-}
-
 void ChassisGimbalManual::wPressing()
 {
-  double final_x_scale = judgeMode(x_scale_);
+  double final_x_scale = x_scale_;
+  if (speed_change_mode_)
+    final_x_scale = x_scale_ * speed_change_scale_;
   vel_cmd_sender_->setLinearXVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
                                      final_x_scale * gyro_move_reduction_ :
                                      final_x_scale);
@@ -201,7 +196,9 @@ void ChassisGimbalManual::wRelease()
 
 void ChassisGimbalManual::sPressing()
 {
-  double final_x_scale = judgeMode(x_scale_);
+  double final_x_scale = x_scale_;
+  if (speed_change_mode_)
+    final_x_scale = x_scale_ * speed_change_scale_;
   vel_cmd_sender_->setLinearXVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
                                      final_x_scale * gyro_move_reduction_ :
                                      final_x_scale);
@@ -218,7 +215,9 @@ void ChassisGimbalManual::sRelease()
 
 void ChassisGimbalManual::aPressing()
 {
-  double final_y_scale = judgeMode(y_scale_);
+  double final_y_scale = y_scale_;
+  if (speed_change_mode_)
+    final_y_scale = y_scale_ * speed_change_scale_;
   vel_cmd_sender_->setLinearYVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
                                      final_y_scale * gyro_move_reduction_ :
                                      final_y_scale);
@@ -235,7 +234,9 @@ void ChassisGimbalManual::aRelease()
 
 void ChassisGimbalManual::dPressing()
 {
-  double final_y_scale = judgeMode(y_scale_);
+  double final_y_scale = y_scale_;
+  if (speed_change_mode_)
+    final_y_scale = y_scale_ * speed_change_scale_;
   vel_cmd_sender_->setLinearYVel(chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::GYRO ?
                                      final_y_scale * gyro_move_reduction_ :
                                      final_y_scale);

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -60,8 +60,6 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   b_event_.setFalling(boost::bind(&EngineerManual::bRelease, this));
   f_event_.setActiveHigh(boost::bind(&EngineerManual::fPressing, this));
   f_event_.setFalling(boost::bind(&EngineerManual::fRelease, this));
-  shift_e_event_.setRising(boost::bind(&EngineerManual::shiftEPress, this));
-  shift_e_event_.setFalling(boost::bind(&EngineerManual::shiftERelease, this));
   shift_z_event_.setRising(boost::bind(&EngineerManual::shiftZPress, this));
   shift_c_event_.setRising(boost::bind(&EngineerManual::shiftCPress, this));
   shift_v_event_.setRising(boost::bind(&EngineerManual::shiftVPress, this));
@@ -71,8 +69,6 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   shift_x_event_.setRising(boost::bind(&EngineerManual::shiftXPress, this));
   shift_g_event_.setRising(boost::bind(&EngineerManual::shiftGPress, this));
   shift_r_event_.setRising(boost::bind(&EngineerManual::shiftRPress, this));
-  shift_q_event_.setRising(boost::bind(&EngineerManual::shiftQPress, this));
-  shift_q_event_.setFalling(boost::bind(&EngineerManual::shiftQRelease, this));
   shift_event_.setActiveHigh(boost::bind(&EngineerManual::shiftPressing, this));
   shift_event_.setFalling(boost::bind(&EngineerManual::shiftRelease, this));
   mouse_left_event_.setFalling(boost::bind(&EngineerManual::mouseLeftRelease, this));
@@ -114,8 +110,8 @@ void EngineerManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)
   g_event_.update(dbus_data->key_g & !dbus_data->key_ctrl & !dbus_data->key_shift);
   f_event_.update(dbus_data->key_f & !dbus_data->key_ctrl & !dbus_data->key_shift);
   r_event_.update(dbus_data->key_r & !dbus_data->key_ctrl & !dbus_data->key_shift);
-  q_event_.update(dbus_data->key_q & !dbus_data->key_ctrl & !dbus_data->key_shift);
-  e_event_.update(dbus_data->key_e & !dbus_data->key_ctrl & !dbus_data->key_shift);
+  q_event_.update(dbus_data->key_q & !dbus_data->key_ctrl);
+  e_event_.update(dbus_data->key_e & !dbus_data->key_ctrl);
 
   shift_z_event_.update(dbus_data->key_shift & dbus_data->key_z);
   shift_x_event_.update(dbus_data->key_shift & dbus_data->key_x);
@@ -418,7 +414,10 @@ void EngineerManual::ctrlBPress()
 
 void EngineerManual::qPressing()
 {
-  vel_cmd_sender_->setAngularZVel(0.3);
+  if (speed_change_mode_ == 1)
+    vel_cmd_sender_->setAngularZVel(0.1);
+  else
+    vel_cmd_sender_->setAngularZVel(0.3);
 }
 
 void EngineerManual::qRelease()
@@ -428,7 +427,10 @@ void EngineerManual::qRelease()
 
 void EngineerManual::ePressing()
 {
-  vel_cmd_sender_->setAngularZVel(-0.3);
+  if (speed_change_mode_ == 1)
+    vel_cmd_sender_->setAngularZVel(-0.1);
+  else
+    vel_cmd_sender_->setAngularZVel(-0.3);
 }
 
 void EngineerManual::eRelease()
@@ -491,29 +493,10 @@ void EngineerManual::fRelease()
 void EngineerManual::shiftPressing()
 {
   speed_change_mode_ = 1;
-  std::cout << "enter low_speed" << std::endl;
 }
 void EngineerManual::shiftRelease()
 {
   speed_change_mode_ = 0;
-  std::cout << "out low_speed" << std::endl;
-
-}
-void EngineerManual::shiftQPress()
-{
-  vel_cmd_sender_->setAngularZVel(0.1);
-}
-void EngineerManual::shiftQRelease()
-{
-  vel_cmd_sender_->setAngularZVel(0);
-}
-void EngineerManual::shiftEPress()
-{
-  vel_cmd_sender_->setAngularZVel(-0.1);
-}
-void EngineerManual::shiftERelease()
-{
-  vel_cmd_sender_->setAngularZVel(0);
 }
 void EngineerManual::shiftRPress()
 {

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -490,9 +490,14 @@ void EngineerManual::fRelease()
 }
 void EngineerManual::shiftPressing()
 {
+  speed_change_mode_ = 1;
+  std::cout << "enter low_speed" << std::endl;
 }
 void EngineerManual::shiftRelease()
 {
+  speed_change_mode_ = 0;
+  std::cout << "out low_speed" << std::endl;
+
 }
 void EngineerManual::shiftQPress()
 {


### PR DESCRIPTION
给chassisgimbal 低速模式 当配置文件存在 low_speed_scale的时候 才认为存在低速模式 否则不存在该模式；主要应用于工程机器人中