### PR TITLE
Modify calibration conditions.

### DIFF
--- a/include/rm_manual/chassis_gimbal_manual.h
+++ b/include/rm_manual/chassis_gimbal_manual.h
@@ -25,6 +25,7 @@ protected:
   void rightSwitchUpRise() override;
   void leftSwitchMidFall() override;
   void leftSwitchDownRise() override;
+  void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void gameStatusCallback(const rm_msgs::GameStatus::ConstPtr& data) override;
   void gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data) override;
   void powerHeatDataCallback(const rm_msgs::PowerHeatData::ConstPtr& data) override;
@@ -60,10 +61,13 @@ protected:
   rm_common::Vel2DCommandSender* vel_cmd_sender_{};
   rm_common::GimbalCommandSender* gimbal_cmd_sender_{};
   rm_common::ChassisCommandSender* chassis_cmd_sender_{};
+
   double x_scale_{}, y_scale_{};
   double gimbal_scale_{ 1. };
   double gyro_move_reduction_{ 1. };
   double gyro_rotate_reduction_{ 1. };
+  ros::Time chassis_actuator_last_get_stamp_, gimbal_actuator_last_get_stamp_;
+  std::vector<std::string> chassis_calibrate_motor_, gimbal_calibrate_motor_;
 
   InputEvent chassis_power_on_event_, gimbal_power_on_event_, w_event_, s_event_, a_event_, d_event_;
 };

--- a/include/rm_manual/chassis_gimbal_manual.h
+++ b/include/rm_manual/chassis_gimbal_manual.h
@@ -25,7 +25,6 @@ protected:
   void rightSwitchUpRise() override;
   void leftSwitchMidFall() override;
   void leftSwitchDownRise() override;
-  void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void gameStatusCallback(const rm_msgs::GameStatus::ConstPtr& data) override;
   void gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data) override;
   void powerHeatDataCallback(const rm_msgs::PowerHeatData::ConstPtr& data) override;

--- a/include/rm_manual/chassis_gimbal_manual.h
+++ b/include/rm_manual/chassis_gimbal_manual.h
@@ -68,9 +68,7 @@ protected:
   double gimbal_scale_{ 1. };
   double gyro_move_reduction_{ 1. };
   double gyro_rotate_reduction_{ 1. };
-  ros::Time chassis_actuator_last_get_stamp_, gimbal_actuator_last_get_stamp_;
-  std::vector<std::string> chassis_calibrate_motor_, gimbal_calibrate_motor_;
 
-  InputEvent chassis_power_on_event_, gimbal_power_on_event_, w_event_, s_event_, a_event_, d_event_;
+  InputEvent w_event_, s_event_, a_event_, d_event_;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -20,6 +20,7 @@ protected:
   void checkReferee() override;
   void sendCommand(const ros::Time& time) override;
   void gimbalOutputOn() override;
+  void chassisOutputOn() override;
   void remoteControlTurnOff() override;
   void remoteControlTurnOn() override;
   void rightSwitchDownRise() override;
@@ -34,6 +35,7 @@ protected:
 
   rm_common::JointPositionBinaryCommandSender* cover_command_sender_{};
   rm_common::CalibrationQueue* gimbal_calibration_;
+  rm_common::CalibrationQueue* chassis_calibration_;
 
   bool supply_ = false;
   bool cover_close_ = true;

--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -31,11 +31,14 @@ protected:
     gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
   };
   void ctrlQPress();
+
   rm_common::JointPositionBinaryCommandSender* cover_command_sender_{};
   rm_common::CalibrationQueue* gimbal_calibration_;
-  InputEvent ctrl_z_event_, ctrl_q_event_;
-  std::string supply_frame_;
+
   bool supply_ = false;
   bool cover_close_ = true;
+  std::string supply_frame_;
+
+  InputEvent ctrl_z_event_, ctrl_q_event_;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -37,9 +37,9 @@ protected:
   rm_common::CalibrationQueue* gimbal_calibration_;
   rm_common::CalibrationQueue* chassis_calibration_;
 
-  bool supply_ = false;
-  bool cover_close_ = true;
-  std::string supply_frame_;
+  std::string supply_frame_, flank_frame_;
+  bool supply_ = false, flank_ = false;
+  bool cover_close_ = true, need_flank_ = false;
 
   InputEvent ctrl_z_event_, ctrl_q_event_;
 };

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "rm_manual/chassis_gimbal_manual.h"
-#include <rm_common/decision/calibration_queue.h>
 
 namespace rm_manual
 {

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -41,6 +41,7 @@ protected:
   void leftSwitchMidRise() override;
   void leftSwitchMidOn(ros::Duration duration);
   void leftSwitchUpRise() override;
+  void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data) override;
   void powerHeatDataCallback(const rm_msgs::PowerHeatData::ConstPtr& data) override;
   void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data) override;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -41,6 +41,7 @@ protected:
   void leftSwitchMidRise() override;
   void leftSwitchMidOn(ros::Duration duration);
   void leftSwitchUpRise() override;
+  void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data) override;
   void powerHeatDataCallback(const rm_msgs::PowerHeatData::ConstPtr& data) override;
   void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data) override;
@@ -83,11 +84,15 @@ protected:
   void ctrlRPress();
   void ctrlBPress();
 
-  InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
-      ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
+
+  ros::Time shooter_actuator_last_get_stamp_;
+  std::vector<std::string> shooter_calibrate_motor_;
+
+  InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
+      f_event_, b_event_, x_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
+      ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -95,17 +95,14 @@ protected:
   void ctrlRPress();
   void ctrlBPress();
 
-  InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
-      ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
+  InputEvent self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_, f_event_, b_event_,
+      x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_, ctrl_shift_b_event_,
+      mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 
   bool prepare_shoot_ = false;
-
-  ros::Time shooter_actuator_last_get_stamp_;
-  std::vector<std::string> shooter_calibrate_motor_;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -41,7 +41,6 @@ protected:
   void leftSwitchMidRise() override;
   void leftSwitchMidOn(ros::Duration duration);
   void leftSwitchUpRise() override;
-  void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data) override;
   void powerHeatDataCallback(const rm_msgs::PowerHeatData::ConstPtr& data) override;
   void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data) override;

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -28,6 +28,7 @@ protected:
   void move(rm_common::JointPointCommandSender* joint, double ch);
   void recordPosition(const rm_msgs::DbusData::ConstPtr& dbus_data);
 
+  void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data) override;
 
   rm_common::JointPointCommandSender *trigger_sender_, *friction_left_sender_, *friction_right_sender_;
@@ -37,6 +38,9 @@ protected:
   double qd_, upward_vel_;
   double scale_{ 0.04 };
   bool if_stop_{ true };
+
+  ros::Time chassis_actuator_last_get_stamp_, gimbal_actuator_last_get_stamp_;
+  std::vector<std::string> chassis_calibrate_motor_, gimbal_calibrate_motor_;
 
   InputEvent chassis_power_on_event_, gimbal_power_on_event_;
 };

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -28,7 +28,6 @@ protected:
   void move(rm_common::JointPointCommandSender* joint, double ch);
   void recordPosition(const rm_msgs::DbusData::ConstPtr& dbus_data);
 
-  void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data) override;
 
   rm_common::JointPointCommandSender *trigger_sender_, *friction_left_sender_, *friction_right_sender_;

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -38,10 +38,5 @@ protected:
   double qd_, upward_vel_;
   double scale_{ 0.04 };
   bool if_stop_{ true };
-
-  ros::Time chassis_actuator_last_get_stamp_, gimbal_actuator_last_get_stamp_;
-  std::vector<std::string> chassis_calibrate_motor_, gimbal_calibrate_motor_;
-
-  InputEvent chassis_power_on_event_, gimbal_power_on_event_;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -69,9 +69,7 @@ protected:
   virtual void odomCallback(const nav_msgs::Odometry::ConstPtr& data)
   {
   }
-  virtual void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
-  {
-  }
+  virtual void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data);
   virtual void gameRobotHpCallback(const rm_msgs::GameRobotHp::ConstPtr& data)
   {
   }
@@ -137,6 +135,10 @@ protected:
   int robot_id_, chassis_power_;
   InputEvent robot_hp_event_, right_switch_down_event_, right_switch_mid_event_, right_switch_up_event_,
       left_switch_down_event_, left_switch_mid_event_, left_switch_up_event_;
+
+  InputEvent chassis_power_on_event_, gimbal_power_on_event_, shooter_power_on_event_;
+  ros::Time chassis_actuator_last_get_stamp_, gimbal_actuator_last_get_stamp_, shooter_actuator_last_get_stamp_;
+  std::vector<std::string> chassis_calibrate_motor_, gimbal_calibrate_motor_, shooter_calibrate_motor_;
 };
 
 }  // namespace rm_manual

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -138,7 +138,7 @@ protected:
 
   InputEvent chassis_power_on_event_, gimbal_power_on_event_, shooter_power_on_event_;
   ros::Time chassis_actuator_last_get_stamp_, gimbal_actuator_last_get_stamp_, shooter_actuator_last_get_stamp_;
-  std::vector<std::string> chassis_calibrate_motor_, gimbal_calibrate_motor_, shooter_calibrate_motor_;
+  std::vector<std::string> chassis_mount_motor_, gimbal_mount_motor_, shooter_mount_motor_;
 };
 
 }  // namespace rm_manual

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -19,6 +19,7 @@
 #include <rm_common/ros_utilities.h>
 #include <rm_common/decision/command_sender.h>
 #include <rm_common/decision/controller_manager.h>
+#include <rm_common/decision/calibration_queue.h>
 
 #include <rm_msgs/DbusData.h>
 #include <rm_msgs/TrackData.h>

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -53,6 +53,8 @@ protected:
   virtual void updateRc(const rm_msgs::DbusData::ConstPtr& dbus_data);
   virtual void updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data);
   virtual void sendCommand(const ros::Time& time) = 0;
+  virtual void updateActuatorStamp(const rm_msgs::ActuatorState::ConstPtr& data, std::vector<std::string> act_vector,
+                                   ros::Time& last_get_stamp);
 
   virtual void jointStateCallback(const sensor_msgs::JointState::ConstPtr& data);
   virtual void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data);

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -69,8 +69,8 @@ void ChassisGimbalManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
 void ChassisGimbalManual::checkReferee()
 {
   ManualBase::checkReferee();
-  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(0.5));
-  gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(0.5));
+  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(0.7));
+  gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(0.7));
 }
 
 void ChassisGimbalManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -18,21 +18,6 @@ ChassisGimbalManual::ChassisGimbalManual(ros::NodeHandle& nh, ros::NodeHandle& n
     ROS_ERROR("Gyro move reduction no defined (namespace: %s)", nh.getNamespace().c_str());
   if (!vel_nh.getParam("gyro_rotate_reduction", gyro_rotate_reduction_))
     ROS_ERROR("Gyro rotate reduction no defined (namespace: %s)", nh.getNamespace().c_str());
-  XmlRpc::XmlRpcValue xml;
-  if (!nh.getParam("chassis_calibrate_motor", xml))
-    ROS_ERROR("chassis_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
-  else
-    for (int i = 0; i < xml.size(); i++)
-    {
-      chassis_calibrate_motor_.push_back(xml[i]);
-    }
-  if (!nh.getParam("gimbal_calibrate_motor", xml))
-    ROS_ERROR("gimbal_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
-  else
-    for (int i = 0; i < xml.size(); i++)
-    {
-      gimbal_calibrate_motor_.push_back(xml[i]);
-    }
   ros::NodeHandle gimbal_nh(nh, "gimbal");
   gimbal_cmd_sender_ = new rm_common::GimbalCommandSender(gimbal_nh);
 

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -28,8 +28,9 @@ ChassisGimbalManual::ChassisGimbalManual(ros::NodeHandle& nh, ros::NodeHandle& n
     ROS_ERROR("gimbal_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
   else
     for (int i = 0; i < xml.size(); i++)
+    {
       gimbal_calibrate_motor_.push_back(xml[i]);
-
+    }
   ros::NodeHandle gimbal_nh(nh, "gimbal");
   gimbal_cmd_sender_ = new rm_common::GimbalCommandSender(gimbal_nh);
 

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -69,8 +69,6 @@ void ChassisGimbalManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
 void ChassisGimbalManual::checkReferee()
 {
   ManualBase::checkReferee();
-  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(0.7));
-  gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(0.7));
 }
 
 void ChassisGimbalManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)
@@ -98,8 +96,7 @@ void ChassisGimbalManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_
 
 void ChassisGimbalManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
 {
-  updateActuatorStamp(data, chassis_calibrate_motor_, chassis_actuator_last_get_stamp_);
-  updateActuatorStamp(data, gimbal_calibrate_motor_, gimbal_actuator_last_get_stamp_);
+  ManualBase::actuatorStateCallback(data);
 }
 
 void ChassisGimbalManual::gameStatusCallback(const rm_msgs::GameStatus::ConstPtr& data)

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -79,11 +79,6 @@ void ChassisGimbalManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_
   }
 }
 
-void ChassisGimbalManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
-{
-  ManualBase::actuatorStateCallback(data);
-}
-
 void ChassisGimbalManual::gameStatusCallback(const rm_msgs::GameStatus::ConstPtr& data)
 {
   ManualBase::gameStatusCallback(data);

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -81,8 +81,8 @@ void ChassisGimbalManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
 void ChassisGimbalManual::checkReferee()
 {
   ManualBase::checkReferee();
-  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(0.3));
-  gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(0.3));
+  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(0.5));
+  gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(0.5));
 }
 
 void ChassisGimbalManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)

--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -30,8 +30,10 @@ void ChassisGimbalShooterCoverManual::run()
 {
   ChassisGimbalShooterManual::run();
   gimbal_calibration_->update(ros::Time::now());
-  if(chassis_calibration_)
-  chassis_calibration_->update(ros::Time::now());
+  if (chassis_calibration_)
+  {
+    chassis_calibration_->update(ros::Time::now());
+  }
 }
 
 void ChassisGimbalShooterCoverManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)

--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -30,6 +30,7 @@ void ChassisGimbalShooterCoverManual::run()
 {
   ChassisGimbalShooterManual::run();
   gimbal_calibration_->update(ros::Time::now());
+  if(chassis_calibration_)
   chassis_calibration_->update(ros::Time::now());
 }
 

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -22,7 +22,9 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
     ROS_ERROR("shooter_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
   else
     for (int i = 0; i < xml.size(); i++)
+    {
       shooter_calibrate_motor_.push_back(xml[i]);
+    }
 
   shooter_power_on_event_.setRising(boost::bind(&ChassisGimbalShooterManual::shooterOutputOn, this));
   self_inspection_event_.setRising(boost::bind(&ChassisGimbalShooterManual::selfInspectionStart, this));

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -65,7 +65,7 @@ void ChassisGimbalShooterManual::checkReferee()
   manual_to_referee_pub_data_.det_target = switch_detection_srv_->getTarget();
   manual_to_referee_pub_data_.stamp = ros::Time::now();
   ChassisGimbalManual::checkReferee();
-  shooter_power_on_event_.update((ros::Time::now() - shooter_actuator_last_get_stamp_) < ros::Duration(0.5));
+  shooter_power_on_event_.update((ros::Time::now() - shooter_actuator_last_get_stamp_) < ros::Duration(0.7));
 }
 
 void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -68,7 +68,6 @@ void ChassisGimbalShooterManual::checkReferee()
   manual_to_referee_pub_data_.det_target = switch_detection_srv_->getTarget();
   manual_to_referee_pub_data_.stamp = ros::Time::now();
   ChassisGimbalManual::checkReferee();
-  shooter_power_on_event_.update((ros::Time::now() - shooter_actuator_last_get_stamp_) < ros::Duration(0.7));
 }
 
 void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)
@@ -95,7 +94,6 @@ void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr
 void ChassisGimbalShooterManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
 {
   ChassisGimbalManual::actuatorStateCallback(data);
-  updateActuatorStamp(data, shooter_calibrate_motor_, shooter_actuator_last_get_stamp_);
 }
 
 void ChassisGimbalShooterManual::gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data)

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -19,14 +19,6 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   XmlRpc::XmlRpcValue rpc_value;
   nh.getParam("shooter_calibration", rpc_value);
   shooter_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
-  XmlRpc::XmlRpcValue xml;
-  if (!nh.getParam("shooter_calibrate_motor", xml))
-    ROS_ERROR("shooter_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
-  else
-    for (int i = 0; i < xml.size(); i++)
-    {
-      shooter_calibrate_motor_.push_back(xml[i]);
-    }
 
   shooter_power_on_event_.setRising(boost::bind(&ChassisGimbalShooterManual::shooterOutputOn, this));
   self_inspection_event_.setRising(boost::bind(&ChassisGimbalShooterManual::selfInspectionStart, this));
@@ -89,11 +81,6 @@ void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr
   ctrl_shift_b_event_.update(dbus_data->key_ctrl & dbus_data->key_shift & dbus_data->key_b);
   mouse_left_event_.update(dbus_data->p_l);
   mouse_right_event_.update(dbus_data->p_r);
-}
-
-void ChassisGimbalShooterManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
-{
-  ChassisGimbalManual::actuatorStateCallback(data);
 }
 
 void ChassisGimbalShooterManual::gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data)

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -63,7 +63,7 @@ void ChassisGimbalShooterManual::checkReferee()
   manual_to_referee_pub_data_.det_target = switch_detection_srv_->getTarget();
   manual_to_referee_pub_data_.stamp = ros::Time::now();
   ChassisGimbalManual::checkReferee();
-  shooter_power_on_event_.update((ros::Time::now() - shooter_actuator_last_get_stamp_) < ros::Duration(0.3));
+  shooter_power_on_event_.update((ros::Time::now() - shooter_actuator_last_get_stamp_) < ros::Duration(0.5));
 }
 
 void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)

--- a/src/dart_manual.cpp
+++ b/src/dart_manual.cpp
@@ -55,15 +55,12 @@ void DartManual::run()
 
 void DartManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
 {
-  updateActuatorStamp(data, chassis_calibrate_motor_, chassis_actuator_last_get_stamp_);
-  updateActuatorStamp(data, gimbal_calibrate_motor_, gimbal_actuator_last_get_stamp_);
+  ManualBase::actuatorStateCallback(data);
 }
 
 void DartManual::gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data)
 {
   ManualBase::gameRobotStatusCallback(data);
-  chassis_power_on_event_.update(data->mains_power_chassis_output);
-  gimbal_power_on_event_.update(data->mains_power_gimbal_output);
 }
 
 void DartManual::sendCommand(const ros::Time& time)
@@ -101,8 +98,6 @@ void DartManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
 void DartManual::checkReferee()
 {
   ManualBase::checkReferee();
-  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(0.3));
-  gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(0.3));
 }
 
 void DartManual::remoteControlTurnOn()

--- a/src/dart_manual.cpp
+++ b/src/dart_manual.cpp
@@ -26,19 +26,6 @@ DartManual::DartManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee) : Manua
   trigger_calibration_ = new rm_common::CalibrationQueue(trigger_rpc_value, nh, controller_manager_);
   nh.getParam("gimbal_calibration", gimbal_rpc_value);
   gimbal_calibration_ = new rm_common::CalibrationQueue(gimbal_rpc_value, nh, controller_manager_);
-  XmlRpc::XmlRpcValue xml;
-  if (!nh.getParam("chassis_calibrate_motor", xml))
-    ROS_ERROR("chassis_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
-  else
-    for (int i = 0; i < xml.size(); i++)
-    {
-      chassis_calibrate_motor_.push_back(xml[i]);
-    }
-  if (!nh.getParam("gimbal_calibrate_motor", xml))
-    ROS_ERROR("gimbal_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
-  else
-    for (int i = 0; i < xml.size(); i++)
-      gimbal_calibrate_motor_.push_back(xml[i]);
 
   left_switch_up_event_.setEdge(boost::bind(&DartManual::leftSwitchUpRise, this),
                                 boost::bind(&DartManual::leftSwitchUpFall, this));
@@ -51,11 +38,6 @@ void DartManual::run()
   ManualBase::run();
   trigger_calibration_->update(ros::Time::now());
   gimbal_calibration_->update(ros::Time::now());
-}
-
-void DartManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
-{
-  ManualBase::actuatorStateCallback(data);
 }
 
 void DartManual::gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data)

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -40,6 +40,27 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   left_switch_mid_event_.setEdge(boost::bind(&ManualBase::leftSwitchMidRise, this),
                                  boost::bind(&ManualBase::leftSwitchMidFall, this));
   robot_hp_event_.setEdge(boost::bind(&ManualBase::robotRevive, this), boost::bind(&ManualBase::robotDie, this));
+
+  XmlRpc::XmlRpcValue xml;
+  if (!nh.getParam("chassis_calibrate_motor", xml))
+    ROS_ERROR("chassis_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
+  else
+    for (int i = 0; i < xml.size(); i++)
+    {
+      chassis_calibrate_motor_.push_back(xml[i]);
+    }
+  if (!nh.getParam("gimbal_calibrate_motor", xml))
+    ROS_ERROR("gimbal_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
+  else
+    for (int i = 0; i < xml.size(); i++)
+      gimbal_calibrate_motor_.push_back(xml[i]);
+  if (!nh.getParam("shooter_calibrate_motor", xml))
+    ROS_ERROR("shooter_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
+  else
+    for (int i = 0; i < xml.size(); i++)
+    {
+      shooter_calibrate_motor_.push_back(xml[i]);
+    }
 }
 
 void ManualBase::run()

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -79,7 +79,7 @@ void ManualBase::jointStateCallback(const sensor_msgs::JointState::ConstPtr& dat
 
 void ManualBase::dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data)
 {
-  if (ros::Time::now() - data->stamp < ros::Duration(0.2))
+  if (ros::Time::now() - data->stamp < ros::Duration(0.4))
   {
     if (!remote_is_open_)
     {

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -54,6 +54,24 @@ void ManualBase::checkReferee()
   manual_to_referee_pub_.publish(manual_to_referee_pub_data_);
 }
 
+void ManualBase::updateActuatorStamp(const rm_msgs::ActuatorState::ConstPtr& data, std::vector<std::string> act_vector,
+                                     ros::Time& last_get_stamp)
+{
+  int dis;
+  for (long unsigned int i = 0; i < act_vector.size(); i++)
+  {
+    auto it = std::find(data->name.begin(), data->name.end(), act_vector.at(i));
+    if (it == data->name.end())
+    {
+      ROS_WARN("can't find actuator named \"%s\" in ActuatorStateData", act_vector.at(i).c_str());
+      continue;
+    }
+    dis = std::distance(data->name.begin(), it);
+    if (data->stamp.at(dis) > last_get_stamp)
+      last_get_stamp = data->stamp.at(dis);
+  }
+}
+
 void ManualBase::jointStateCallback(const sensor_msgs::JointState::ConstPtr& data)
 {
   joint_state_ = *data;

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -46,9 +46,7 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
     ROS_ERROR("chassis_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
   else
     for (int i = 0; i < xml.size(); i++)
-    {
       chassis_calibrate_motor_.push_back(xml[i]);
-    }
   if (!nh.getParam("gimbal_calibrate_motor", xml))
     ROS_ERROR("gimbal_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
   else
@@ -58,9 +56,7 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
     ROS_ERROR("shooter_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
   else
     for (int i = 0; i < xml.size(); i++)
-    {
       shooter_calibrate_motor_.push_back(xml[i]);
-    }
 }
 
 void ManualBase::run()

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -46,17 +46,17 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
     ROS_ERROR("chassis_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
   else
     for (int i = 0; i < xml.size(); i++)
-      chassis_calibrate_motor_.push_back(xml[i]);
+      chassis_mount_motor_.push_back(xml[i]);
   if (!nh.getParam("gimbal_calibrate_motor", xml))
     ROS_ERROR("gimbal_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
   else
     for (int i = 0; i < xml.size(); i++)
-      gimbal_calibrate_motor_.push_back(xml[i]);
+      gimbal_mount_motor_.push_back(xml[i]);
   if (!nh.getParam("shooter_calibrate_motor", xml))
     ROS_ERROR("shooter_calibrate_motor no defined (namespace: %s)", nh.getNamespace().c_str());
   else
     for (int i = 0; i < xml.size(); i++)
-      shooter_calibrate_motor_.push_back(xml[i]);
+      shooter_mount_motor_.push_back(xml[i]);
 }
 
 void ManualBase::run()
@@ -99,9 +99,9 @@ void ManualBase::jointStateCallback(const sensor_msgs::JointState::ConstPtr& dat
 
 void ManualBase::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
 {
-  updateActuatorStamp(data, chassis_calibrate_motor_, chassis_actuator_last_get_stamp_);
-  updateActuatorStamp(data, gimbal_calibrate_motor_, gimbal_actuator_last_get_stamp_);
-  updateActuatorStamp(data, shooter_calibrate_motor_, shooter_actuator_last_get_stamp_);
+  updateActuatorStamp(data, chassis_mount_motor_, chassis_actuator_last_get_stamp_);
+  updateActuatorStamp(data, gimbal_mount_motor_, gimbal_actuator_last_get_stamp_);
+  updateActuatorStamp(data, shooter_mount_motor_, shooter_actuator_last_get_stamp_);
 }
 
 void ManualBase::dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data)

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -50,6 +50,9 @@ void ManualBase::run()
 
 void ManualBase::checkReferee()
 {
+  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(0.7));
+  gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(0.7));
+  shooter_power_on_event_.update((ros::Time::now() - shooter_actuator_last_get_stamp_) < ros::Duration(0.7));
   referee_is_online_ = (ros::Time::now() - referee_last_get_stamp_ < ros::Duration(0.3));
   manual_to_referee_pub_.publish(manual_to_referee_pub_data_);
 }
@@ -75,6 +78,13 @@ void ManualBase::updateActuatorStamp(const rm_msgs::ActuatorState::ConstPtr& dat
 void ManualBase::jointStateCallback(const sensor_msgs::JointState::ConstPtr& data)
 {
   joint_state_ = *data;
+}
+
+void ManualBase::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
+{
+  updateActuatorStamp(data, chassis_calibrate_motor_, chassis_actuator_last_get_stamp_);
+  updateActuatorStamp(data, gimbal_calibrate_motor_, gimbal_actuator_last_get_stamp_);
+  updateActuatorStamp(data, shooter_calibrate_motor_, shooter_actuator_last_get_stamp_);
 }
 
 void ManualBase::dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data)


### PR DESCRIPTION
原来机器人的上电校准数据源是裁判系统的数据，该数据会显示机器人底盘，云台和发射机构是否处于上电状态。考虑到官方裁判系统和机器人串口并不稳定，将校准的数据源改为/actuator_states话题，根据话题是否有数据来判断上电情况。这种方式能够避免因为串口断连，数据错误引起的无法校准，同时在掉can重连的情况下也可以重新进行校准。
校准逻辑：在参数文件中规定底盘，云台，发射机构需要校准的电机，程序会检索相应电机的时间戳，若时间戳触发了一个重新更新的上升沿则重置相应的校准队列。
目前在步兵和平衡步兵上进行了测试。

因为误操作的原因，平衡步兵的侧向对敌被合并进了改分支且原分支已被删除，所以本分支有侧向对敌的代码。