### PR TITLE
Add key for switching camera

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -65,6 +65,7 @@ protected:
   void ePress();
   void cPress();
   void bPress();
+  void rPress();
   void qPress()
   {
     if (shooter_cmd_sender_->getShootFrequency() != rm_common::HeatLimit::LOW)
@@ -84,9 +85,10 @@ protected:
   void ctrlBPress();
 
   InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
+      f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
       ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
+  rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 };

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -308,11 +308,7 @@ void ChassisGimbalShooterManual::bPress()
 
 void ChassisGimbalShooterManual::rPress()
 {
-  std::string current_camera = camera_switch_cmd_sender_->getCurrentCameraName();
-  if (current_camera == camera_switch_cmd_sender_->getCameraOneName())
-    camera_switch_cmd_sender_->switchCameraTwo();
-  else
-    camera_switch_cmd_sender_->switchCameraOne();
+  camera_switch_cmd_sender_->switchCamera();
 }
 
 void ChassisGimbalShooterManual::wPress()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -309,10 +309,10 @@ void ChassisGimbalShooterManual::bPress()
 void ChassisGimbalShooterManual::rPress()
 {
   std::string current_camera = camera_switch_cmd_sender_->getCurrentCameraName();
-  if (current_camera == camera_switch_cmd_sender_->getShortCameraName())
-    camera_switch_cmd_sender_->switchLongCamera();
+  if (current_camera == camera_switch_cmd_sender_->getCameraOneName())
+    camera_switch_cmd_sender_->switchCameraTwo();
   else
-    camera_switch_cmd_sender_->switchShortCamera();
+    camera_switch_cmd_sender_->switchCameraOne();
 }
 
 void ChassisGimbalShooterManual::wPress()


### PR DESCRIPTION
1. 增加了一个用于切换相机的键位。
2. 实现：当按下键位时，如果当前使用的是长焦会向话题发一个表示短焦的字符串；相机节点接收后，会根据这个字符串决定哪个节点阻塞，哪个推流，反过来一样。