### PR TITLE
Modify the logic of clicking the left mouse button

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -52,7 +52,7 @@ protected:
   void mouseLeftRelease()
   {
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
-    start_shooting_ = false;
+    prepare_shoot_ = true;
   }
   void mouseRightPress();
   void mouseRightRelease()
@@ -91,6 +91,6 @@ protected:
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 
-  bool start_shooting_ = false;
+  bool prepare_shoot_ = false;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -48,7 +48,7 @@ protected:
   void gimbalDesErrorCallback(const rm_msgs::GimbalDesError::ConstPtr& data) override;
   void trackCallback(const rm_msgs::TrackData::ConstPtr& data) override;
   void leftSwitchUpOn(ros::Duration duration);
-  void mouseLeftPress();
+  void mouseLeftPress(ros::Duration duration);
   void mouseLeftRelease()
   {
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -48,10 +48,11 @@ protected:
   void gimbalDesErrorCallback(const rm_msgs::GimbalDesError::ConstPtr& data) override;
   void trackCallback(const rm_msgs::TrackData::ConstPtr& data) override;
   void leftSwitchUpOn(ros::Duration duration);
-  void mouseLeftPress(ros::Duration duration);
+  void mouseLeftPress();
   void mouseLeftRelease()
   {
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
+    start_shooting_ = false;
   }
   void mouseRightPress();
   void mouseRightRelease()
@@ -89,5 +90,7 @@ protected:
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
+
+  bool start_shooting_ = false;
 };
 }  // namespace rm_manual

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -34,7 +34,7 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   ctrl_b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlBPress, this));
   shift_event_.setEdge(boost::bind(&ChassisGimbalShooterManual::shiftPress, this),
                        boost::bind(&ChassisGimbalShooterManual::shiftRelease, this));
-  mouse_left_event_.setActiveHigh(boost::bind(&ChassisGimbalShooterManual::mouseLeftPress, this, _1));
+  mouse_left_event_.setActiveHigh(boost::bind(&ChassisGimbalShooterManual::mouseLeftPress, this));
   mouse_left_event_.setFalling(boost::bind(&ChassisGimbalShooterManual::mouseLeftRelease, this));
   mouse_right_event_.setActiveHigh(boost::bind(&ChassisGimbalShooterManual::mouseRightPress, this));
   mouse_right_event_.setFalling(boost::bind(&ChassisGimbalShooterManual::mouseRightRelease, this));
@@ -248,13 +248,18 @@ void ChassisGimbalShooterManual::leftSwitchUpOn(ros::Duration duration)
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
 }
 
-void ChassisGimbalShooterManual::mouseLeftPress(ros::Duration duration)
+void ChassisGimbalShooterManual::mouseLeftPress()
 {
-  if (duration.toSec() < 0.1)
+  if (shooter_cmd_sender_->getMsg()->mode == rm_msgs::ShootCmd::STOP)
+  {
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
-  else
+    start_shooting_ = true;
+  }
+  if (!start_shooting_)
+  {
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::PUSH);
-  shooter_cmd_sender_->checkError(ros::Time::now());
+    shooter_cmd_sender_->checkError(ros::Time::now());
+  }
 }
 
 void ChassisGimbalShooterManual::mouseRightPress()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -34,7 +34,7 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   ctrl_b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlBPress, this));
   shift_event_.setEdge(boost::bind(&ChassisGimbalShooterManual::shiftPress, this),
                        boost::bind(&ChassisGimbalShooterManual::shiftRelease, this));
-  mouse_left_event_.setActiveHigh(boost::bind(&ChassisGimbalShooterManual::mouseLeftPress, this));
+  mouse_left_event_.setActiveHigh(boost::bind(&ChassisGimbalShooterManual::mouseLeftPress, this, _1));
   mouse_left_event_.setFalling(boost::bind(&ChassisGimbalShooterManual::mouseLeftRelease, this));
   mouse_right_event_.setActiveHigh(boost::bind(&ChassisGimbalShooterManual::mouseRightPress, this));
   mouse_right_event_.setFalling(boost::bind(&ChassisGimbalShooterManual::mouseRightRelease, this));
@@ -248,9 +248,9 @@ void ChassisGimbalShooterManual::leftSwitchUpOn(ros::Duration duration)
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
 }
 
-void ChassisGimbalShooterManual::mouseLeftPress()
+void ChassisGimbalShooterManual::mouseLeftPress(ros::Duration duration)
 {
-  if (shooter_cmd_sender_->getMode() == rm_msgs::ShootCmd::STOP)
+  if (duration.toSec() < 0.1)
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
   else
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::PUSH);

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -253,9 +253,9 @@ void ChassisGimbalShooterManual::mouseLeftPress()
   if (shooter_cmd_sender_->getMsg()->mode == rm_msgs::ShootCmd::STOP)
   {
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
-    start_shooting_ = true;
+    prepare_shoot_ = false;
   }
-  if (!start_shooting_)
+  if (prepare_shoot_)
   {
     shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::PUSH);
     shooter_cmd_sender_->checkError(ros::Time::now());

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -250,7 +250,10 @@ void ChassisGimbalShooterManual::leftSwitchUpOn(ros::Duration duration)
 
 void ChassisGimbalShooterManual::mouseLeftPress()
 {
-  shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::PUSH);
+  if (shooter_cmd_sender_->getMode() == rm_msgs::ShootCmd::STOP)
+    shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
+  else
+    shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::PUSH);
   shooter_cmd_sender_->checkError(ros::Time::now());
 }
 


### PR DESCRIPTION
1. 现象：使用键鼠操作时，如果发射的模式为stop，那么第一次点击会先进push模式，但是此时可能由于拨盘期望位置与实际位置相差过大，导致不能执行shooter controller中push函数中的拨盘setcommand函数，以及变量"last_shoot_time_"的更新。这会导致满足判断是否卡弹的逻辑，导致一直在block模式，无法正常发射。
2. 解决方法：将点击鼠标左键的逻辑改为：当鼠标左击时，如果当前为stop模式，先进入ready模式，第二次点击后才进入push模式，这样可以让拨盘执行normalize()，从而通过push的判断，目前在3号进行了测试。