### PR TITLE
2023 engineer manual.

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -75,6 +75,8 @@ protected:
   void ePress();
   void cPress();
   void bPress();
+  void xPress();
+  void xReleasing();
   void rPress();
   void qPress()
   {

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -75,7 +75,6 @@ protected:
   void ePress();
   void cPress();
   void bPress();
-  void rPress();
   void qPress()
   {
     if (shooter_cmd_sender_->getShootFrequency() != rm_common::HeatLimit::LOW)
@@ -95,10 +94,9 @@ protected:
   void ctrlBPress();
 
   InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
+      f_event_, b_event_, x_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
       ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
-  rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -75,8 +75,6 @@ protected:
   void ePress();
   void cPress();
   void bPress();
-  void xPress();
-  void xReleasing();
   void rPress();
   void qPress()
   {
@@ -97,10 +95,11 @@ protected:
   void ctrlBPress();
 
   InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
+      f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
       ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
+  rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 
   bool prepare_shoot_ = false;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -75,6 +75,9 @@ protected:
   void ePress();
   void cPress();
   void bPress();
+  void xPress();
+  void xReleasing();
+  void rPress();
   void qPress()
   {
     if (shooter_cmd_sender_->getShootFrequency() != rm_common::HeatLimit::LOW)

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -120,12 +120,11 @@ private:
   void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
   void sendUi();
 
-  bool reversal_motion_{};
-  bool change_flag_{ 1 }, is_exchange_{}, target_shape_{};
+  bool change_flag_{ 1 }, is_exchange_{}, target_shape_{}, reversal_motion_{};
   int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, max_temperature_{};
   double angular_z_scale_{};
-  std::string prefix_{}, root_{}, drag_state_{}, max_temperature_joint_{}, joint_temperature_{}, reversal_state_{},
-      gripper_state_{};
+  std::string prefix_{}, root_{}, drag_state_{ "on" }, max_temperature_joint_{}, joint_temperature_{},
+      reversal_state_{}, gripper_state_{};
 
   ros::Time last_time_;
   ros::Publisher ui_send_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -138,7 +138,7 @@ private:
   rm_common::MultiDofCommandSender* reversal_command_sender_;
   rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;
   rm_common::JointPositionBinaryCommandSender* drag_command_sender_;
-  rm_common::CalibrationQueue* calibration_gather{};
+  rm_common::CalibrationQueue* calibration_gather_{};
   InputEvent left_switch_up_event_, left_switch_down_event_, ctrl_q_event_, ctrl_a_event_, ctrl_z_event_, ctrl_w_event_,
       ctrl_s_event_, ctrl_x_event_, ctrl_e_event_, ctrl_d_event_, ctrl_c_event_, ctrl_b_event_, ctrl_v_event_, z_event_,
       q_event_, e_event_, x_event_, c_event_, v_event_, b_event_, f_event_, shift_z_event_, shift_x_event_,

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -116,20 +116,14 @@ private:
   void mouseRightRelease();
   void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void exchangeCallback(const rm_msgs::ExchangerMsg::ConstPtr& data);
-  void updateUiDate(std::string step_name, std::string reversal_state, std::string drag_state, uint8_t stone_num,
-                    std::string joint_temperature, std::string gripper_state);
-  bool judgeUiChange(std::string step_name, std::string reversal_state, std::string drag_state, uint8_t stone_num,
-                     std::string joint_temperature, std::string gripper_state);
-  void sendUi(std::string step_name, std::string reversal_state, std::string drag_state, uint8_t stone_num,
-              std::string joint_temperature, std::string gripper_state);
+  void sendUi();
 
   bool reversal_motion_{};
   bool change_flag_{ 1 }, is_exchange_{}, target_shape_{};
-  int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, stone_num_last_{}, max_temperature_{};
+  int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, max_temperature_{};
   double angular_z_scale_{};
-  std::string prefix_{}, root_{}, step_name_last_{}, reversal_state_last_{}, drag_state_{}, drag_state_last_{},
-      max_temperature_joint_{}, joint_temperature_{}, joint_temperature_last_{}, reversal_state_{}, gripper_state_{},
-      gripper_state_last_{};
+  std::string prefix_{}, root_{}, drag_state_{}, max_temperature_joint_{}, joint_temperature_{}, reversal_state_{},
+      gripper_state_{};
 
   ros::Time last_time_;
   ros::Publisher ui_send_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -122,7 +122,7 @@ private:
 
   bool change_flag_{ 1 }, is_exchange_{}, target_shape_{}, reversal_motion_{};
   int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, max_temperature_{};
-  double angular_z_scale_{};
+  double angular_z_scale_{}, gyro_scale_{}, gyro_low_scale_{};
   std::string prefix_{}, root_{}, drag_state_{ "on" }, max_temperature_joint_{}, joint_temperature_{},
       reversal_state_{}, gripper_state_{};
 

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -130,8 +130,7 @@ private:
 
   ros::Time last_time_;
   ros::Publisher ui_send_;
-  ros::Subscriber reversal_vision_sub_, exchange_sub_;
-  ros::Subscriber gripper_state_sub_;
+  ros::Subscriber reversal_vision_sub_, exchange_sub_, gripper_state_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
 
   rm_msgs::EngineerUi engineer_ui_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -21,21 +21,24 @@ namespace rm_manual
 class EngineerManual : public ChassisGimbalManual
 {
 public:
-  enum
+  enum ControlMode
   {
     MANUAL,
     MIDDLEWARE
   };
-  enum
+
+  enum ArmMode
   {
     SERVO,
     JOINT
   };
-  enum
+
+  enum GimbalMode
   {
     RATE,
     DIRECT
   };
+
   EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee);
   void run() override;
 

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -15,6 +15,7 @@
 #include <rm_msgs/EngineerAction.h>
 #include <rm_msgs/EngineerUi.h>
 #include <rm_msgs/MultiDofCmd.h>
+#include <rm_msgs/GpioData.h>
 
 namespace rm_manual
 {
@@ -116,6 +117,7 @@ private:
   void mouseRightRelease();
   void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void exchangeCallback(const rm_msgs::ExchangerMsg::ConstPtr& data);
+  void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
   void sendUi();
 
   bool reversal_motion_{};
@@ -128,9 +130,11 @@ private:
   ros::Time last_time_;
   ros::Publisher ui_send_;
   ros::Subscriber reversal_vision_sub_;
+  ros::Subscriber gripper_state_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
 
   rm_msgs::EngineerUi engineer_ui_;
+  rm_msgs::GpioData gpio_state_;
   rm_common::Vel3DCommandSender* servo_command_sender_;
   rm_common::MultiDofCommandSender* reversal_command_sender_;
   rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -109,9 +109,9 @@ private:
   void bRelease();
   void vPressing();
   void vRelease();
-  void fPressing();
+  void fPress();
   void fRelease();
-  void gPressing();
+  void gPress();
   void gRelease();
   void mouseLeftRelease();
   void mouseRightRelease();

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -124,8 +124,8 @@ private:
               std::string joint_temperature, std::string gripper_state);
 
   bool reversal_motion_{};
-  bool change_flag_ = 1, is_exchange_{}, target_shape_{};
-  int state_, operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, stone_num_last_{}, max_temperature_{};
+  bool change_flag_{ 1 }, is_exchange_{}, target_shape_{};
+  int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, stone_num_last_{}, max_temperature_{};
   double angular_z_scale_{};
   std::string prefix_{}, root_{}, step_name_last_{}, reversal_state_last_{}, drag_state_{}, drag_state_last_{},
       max_temperature_joint_{}, joint_temperature_{}, joint_temperature_last_{}, reversal_state_{}, gripper_state_{},

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -22,6 +22,21 @@ namespace rm_manual
 class EngineerManual : public ChassisGimbalManual
 {
 public:
+  enum
+  {
+    MANUAL,
+    MIDDLEWARE
+  };
+  enum
+  {
+    SERVO,
+    JOINT
+  };
+  enum
+  {
+    RATE,
+    DIRECT
+  };
   EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee);
   void run() override;
 
@@ -109,43 +124,28 @@ private:
                      std::string joint_temperature, std::string gripper_state);
   void sendUi(std::string step_name, std::string reversal_state, std::string drag_state, uint8_t stone_num,
               std::string joint_temperature, std::string gripper_state);
-  enum
-  {
-    MANUAL,
-    MIDDLEWARE
-  };
-  enum
-  {
-    SERVO,
-    JOINT
-  };
-  enum
-  {
-    RATE,
-    DIRECT
-  };
 
-  int state_;
-  bool change_flag_ = 1, is_exchange_, target_shape_;
   bool reversal_motion_{};
-  rm_msgs::StepQueueState step_queue_state_;
-  rm_msgs::EngineerUi engineer_ui_;
-  ros::Publisher ui_send_;
+  bool change_flag_ = 1, is_exchange_, target_shape_;
+  int state_, operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, stone_num_last_{}, max_temperature_{};
   double angular_z_scale_{};
   std::string prefix_, root_, step_name_last_, reversal_state_last_, drag_state_, drag_state_last_,
       max_temperature_joint_, joint_temperature_, joint_temperature_last_, reversal_state_, gripper_state_,
       gripper_state_last_;
-  int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, stone_num_last_{}, max_temperature_{};
-  std::map<std::string, int> prefix_list_, root_list_;
+
   ros::Time last_time_;
+  ros::Publisher ui_send_;
   ros::Subscriber reversal_vision_sub_;
   ros::Publisher step_queue_state_pub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
-  rm_common::CalibrationQueue *power_on_calibration_{}, *arm_calibration_{};
+
+  rm_msgs::EngineerUi engineer_ui_;
+  rm_msgs::StepQueueState step_queue_state_;
   rm_common::Vel3DCommandSender* servo_command_sender_;
-  rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;
   rm_common::MultiDofCommandSender* reversal_command_sender_;
+  rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;
   rm_common::JointPositionBinaryCommandSender* drag_command_sender_;
+  rm_common::CalibrationQueue *power_on_calibration_{}, *arm_calibration_{};
   InputEvent left_switch_up_event_, left_switch_down_event_, ctrl_q_event_, ctrl_a_event_, ctrl_z_event_, ctrl_w_event_,
       ctrl_s_event_, ctrl_x_event_, ctrl_e_event_, ctrl_d_event_, ctrl_c_event_, ctrl_b_event_, ctrl_v_event_, z_event_,
       q_event_, e_event_, x_event_, c_event_, v_event_, b_event_, f_event_, shift_z_event_, shift_x_event_,

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -121,6 +121,7 @@ private:
   void exchangeCallback(const rm_msgs::ExchangerMsg::ConstPtr& data);
   void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
   void sendUi();
+  void judgeJoint7(const ros::Time& time);
 
   bool change_flag_{ 1 }, is_exchange_{}, target_shape_{}, reversal_motion_{};
   int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, max_temperature_{};
@@ -138,7 +139,7 @@ private:
   rm_common::Vel3DCommandSender* servo_command_sender_;
   rm_common::MultiDofCommandSender* reversal_command_sender_;
   rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;
-  rm_common::JointPositionBinaryCommandSender* drag_command_sender_;
+  rm_common::JointPositionBinaryCommandSender *drag_command_sender_, *joint7_command_sender_;
   rm_common::CalibrationQueue* calibration_gather_{};
   InputEvent left_switch_up_event_, left_switch_down_event_, ctrl_q_event_, ctrl_a_event_, ctrl_z_event_, ctrl_w_event_,
       ctrl_s_event_, ctrl_x_event_, ctrl_e_event_, ctrl_d_event_, ctrl_c_event_, ctrl_b_event_, ctrl_v_event_, z_event_,

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -138,7 +138,7 @@ private:
   rm_common::MultiDofCommandSender* reversal_command_sender_;
   rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;
   rm_common::JointPositionBinaryCommandSender* drag_command_sender_;
-  rm_common::CalibrationQueue *power_on_calibration_{}, *arm_calibration_{};
+  rm_common::CalibrationQueue* calibration_gather{};
   InputEvent left_switch_up_event_, left_switch_down_event_, ctrl_q_event_, ctrl_a_event_, ctrl_z_event_, ctrl_w_event_,
       ctrl_s_event_, ctrl_x_event_, ctrl_e_event_, ctrl_d_event_, ctrl_c_event_, ctrl_b_event_, ctrl_v_event_, z_event_,
       q_event_, e_event_, x_event_, c_event_, v_event_, b_event_, f_event_, shift_z_event_, shift_x_event_,

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -120,10 +120,12 @@ private:
   void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
   void exchangeCallback(const rm_msgs::ExchangerMsg::ConstPtr& data);
   void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
+  void stoneNumCallback(const std_msgs::String ::ConstPtr& data);
   void sendUi();
   void judgeJoint7(const ros::Time& time);
 
-  bool change_flag_{ 1 }, is_exchange_{}, target_shape_{}, reversal_motion_{}, is_auxiliary_camera_{ 0 };
+  bool change_flag_{ true }, is_exchange_{}, target_shape_{}, reversal_motion_{}, is_auxiliary_camera_{ false },
+      is_joint7_up_{ true };
   int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, max_temperature_{};
   double angular_z_scale_{}, gyro_scale_{}, gyro_low_scale_{};
   std::string prefix_{}, root_{}, drag_state_{ "on" }, max_temperature_joint_{}, joint_temperature_{},
@@ -131,7 +133,7 @@ private:
 
   ros::Time last_time_;
   ros::Publisher engineer_ui_pub_;
-  ros::Subscriber reversal_vision_sub_, exchange_sub_, gripper_state_sub_;
+  ros::Subscriber reversal_vision_sub_, exchange_sub_, gripper_state_sub_, stone_num_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
 
   rm_msgs::EngineerUi engineer_ui_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -14,6 +14,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <rm_msgs/EngineerAction.h>
 #include <rm_msgs/EngineerUi.h>
+#include <rm_msgs/ExchangerMsg.h>
 #include <rm_msgs/MultiDofCmd.h>
 #include <rm_msgs/GpioData.h>
 
@@ -28,7 +29,7 @@ public:
     MIDDLEWARE
   };
 
-  enum ArmMode
+  enum JointMode
   {
     SERVO,
     JOINT
@@ -113,6 +114,7 @@ private:
   void fRelease();
   void gPress();
   void gRelease();
+
   void mouseLeftRelease();
   void mouseRightRelease();
   void actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data) override;
@@ -128,7 +130,7 @@ private:
 
   ros::Time last_time_;
   ros::Publisher ui_send_;
-  ros::Subscriber reversal_vision_sub_;
+  ros::Subscriber reversal_vision_sub_, exchange_sub_;
   ros::Subscriber gripper_state_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
 

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -13,7 +13,6 @@
 #include <std_msgs/Float64.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <rm_msgs/EngineerAction.h>
-#include <rm_msgs/StepQueueState.h>
 #include <rm_msgs/EngineerUi.h>
 #include <rm_msgs/MultiDofCmd.h>
 
@@ -82,10 +81,6 @@ private:
   void ctrlRPress();
   void shiftPressing();
   void shiftRelease();
-  void shiftQPress();
-  void shiftQRelease();
-  void shiftEPress();
-  void shiftERelease();
   void shiftZPress();
   void shiftXPress();
   void shiftCPress();
@@ -126,21 +121,19 @@ private:
               std::string joint_temperature, std::string gripper_state);
 
   bool reversal_motion_{};
-  bool change_flag_ = 1, is_exchange_, target_shape_;
+  bool change_flag_ = 1, is_exchange_{}, target_shape_{};
   int state_, operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, stone_num_last_{}, max_temperature_{};
   double angular_z_scale_{};
-  std::string prefix_, root_, step_name_last_, reversal_state_last_, drag_state_, drag_state_last_,
-      max_temperature_joint_, joint_temperature_, joint_temperature_last_, reversal_state_, gripper_state_,
-      gripper_state_last_;
+  std::string prefix_{}, root_{}, step_name_last_{}, reversal_state_last_{}, drag_state_{}, drag_state_last_{},
+      max_temperature_joint_{}, joint_temperature_{}, joint_temperature_last_{}, reversal_state_{}, gripper_state_{},
+      gripper_state_last_{};
 
   ros::Time last_time_;
   ros::Publisher ui_send_;
   ros::Subscriber reversal_vision_sub_;
-  ros::Publisher step_queue_state_pub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
 
   rm_msgs::EngineerUi engineer_ui_;
-  rm_msgs::StepQueueState step_queue_state_;
   rm_common::Vel3DCommandSender* servo_command_sender_;
   rm_common::MultiDofCommandSender* reversal_command_sender_;
   rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -129,7 +129,7 @@ private:
       reversal_state_{}, gripper_state_{};
 
   ros::Time last_time_;
-  ros::Publisher ui_send_;
+  ros::Publisher engineer_ui_pub_;
   ros::Subscriber reversal_vision_sub_, exchange_sub_, gripper_state_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
 

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -122,16 +122,13 @@ private:
   void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
   void stoneNumCallback(const std_msgs::String ::ConstPtr& data);
   void sendUi();
-  void judgeJoint7(const ros::Time& time);
 
-  bool change_flag_{ true }, is_exchange_{}, target_shape_{}, reversal_motion_{}, is_auxiliary_camera_{ false },
-      is_joint7_up_{ true };
+  bool change_flag_{ true }, is_exchange_{}, target_shape_{}, reversal_motion_{}, is_joint7_up_{ true };
   int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, max_temperature_{};
   double angular_z_scale_{}, gyro_scale_{}, gyro_low_scale_{};
   std::string prefix_{}, root_{}, drag_state_{ "on" }, max_temperature_joint_{}, joint_temperature_{},
       reversal_state_{}, gripper_state_{};
 
-  ros::Time last_time_;
   ros::Publisher engineer_ui_pub_;
   ros::Subscriber reversal_vision_sub_, exchange_sub_, gripper_state_sub_, stone_num_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -123,7 +123,7 @@ private:
   void sendUi();
   void judgeJoint7(const ros::Time& time);
 
-  bool change_flag_{ 1 }, is_exchange_{}, target_shape_{}, reversal_motion_{};
+  bool change_flag_{ 1 }, is_exchange_{}, target_shape_{}, reversal_motion_{}, is_auxiliary_camera_{ 0 };
   int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, max_temperature_{};
   double angular_z_scale_{}, gyro_scale_{}, gyro_low_scale_{};
   std::string prefix_{}, root_{}, drag_state_{ "on" }, max_temperature_joint_{}, joint_temperature_{},
@@ -140,7 +140,7 @@ private:
   rm_common::MultiDofCommandSender* reversal_command_sender_;
   rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;
   rm_common::JointPositionBinaryCommandSender *drag_command_sender_, *joint7_command_sender_;
-  rm_common::CalibrationQueue* calibration_gather_{};
+  rm_common::CalibrationQueue *calibration_gather_{}, *joint5_calibration_{};
   InputEvent left_switch_up_event_, left_switch_down_event_, ctrl_q_event_, ctrl_a_event_, ctrl_z_event_, ctrl_w_event_,
       ctrl_s_event_, ctrl_x_event_, ctrl_e_event_, ctrl_d_event_, ctrl_c_event_, ctrl_b_event_, ctrl_v_event_, z_event_,
       q_event_, e_event_, x_event_, c_event_, v_event_, b_event_, f_event_, shift_z_event_, shift_x_event_,

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -62,10 +62,10 @@ void ChassisGimbalManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_
   ManualBase::checkKeyboard(dbus_data);
   if (robot_id_ == rm_msgs::GameRobotStatus::RED_ENGINEER || robot_id_ == rm_msgs::GameRobotStatus::BLUE_ENGINEER)
   {
-    w_event_.update((!dbus_data->key_ctrl) && (!dbus_data->key_shift) && dbus_data->key_w);
-    s_event_.update((!dbus_data->key_ctrl) && (!dbus_data->key_shift) && dbus_data->key_s);
-    a_event_.update((!dbus_data->key_ctrl) && (!dbus_data->key_shift) && dbus_data->key_a);
-    d_event_.update((!dbus_data->key_ctrl) && (!dbus_data->key_shift) && dbus_data->key_d);
+    w_event_.update((!dbus_data->key_ctrl) && dbus_data->key_w);
+    s_event_.update((!dbus_data->key_ctrl) && dbus_data->key_s);
+    a_event_.update((!dbus_data->key_ctrl) && dbus_data->key_a);
+    d_event_.update((!dbus_data->key_ctrl) && dbus_data->key_d);
   }
   else
   {

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -11,8 +11,6 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
 {
   ros::NodeHandle shooter_nh(nh, "shooter");
   shooter_cmd_sender_ = new rm_common::ShooterCommandSender(shooter_nh);
-  ros::NodeHandle camera_nh(nh, "camera");
-  camera_switch_cmd_sender_ = new rm_common::CameraSwitchCommandSender(camera_nh);
 
   ros::NodeHandle detection_switch_nh(nh, "detection_switch");
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
@@ -30,7 +28,6 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   q_event_.setRising(boost::bind(&ChassisGimbalShooterManual::qPress, this));
   f_event_.setRising(boost::bind(&ChassisGimbalShooterManual::fPress, this));
   b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::bPress, this));
-  r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::rPress, this));
   ctrl_c_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlCPress, this));
   ctrl_v_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlVPress, this));
   ctrl_r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlRPress, this));
@@ -72,7 +69,6 @@ void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr
   f_event_.update(dbus_data->key_f);
   b_event_.update((!dbus_data->key_ctrl && !dbus_data->key_shift) & dbus_data->key_b);
   x_event_.update(dbus_data->key_x);
-  r_event_.update((!dbus_data->key_ctrl) & dbus_data->key_r);
   ctrl_c_event_.update(dbus_data->key_ctrl & dbus_data->key_c);
   ctrl_v_event_.update(dbus_data->key_ctrl & dbus_data->key_v);
   ctrl_r_event_.update(dbus_data->key_ctrl & dbus_data->key_r);
@@ -126,7 +122,6 @@ void ChassisGimbalShooterManual::sendCommand(const ros::Time& time)
 {
   ChassisGimbalManual::sendCommand(time);
   shooter_cmd_sender_->sendCommand(time);
-  camera_switch_cmd_sender_->sendCommand(time);
 }
 
 void ChassisGimbalShooterManual::remoteControlTurnOff()
@@ -329,11 +324,6 @@ void ChassisGimbalShooterManual::cPress()
 void ChassisGimbalShooterManual::bPress()
 {
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
-}
-
-void ChassisGimbalShooterManual::rPress()
-{
-  camera_switch_cmd_sender_->switchCamera();
 }
 
 void ChassisGimbalShooterManual::wPress()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -48,6 +48,13 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   mouse_right_event_.setFalling(boost::bind(&ChassisGimbalShooterManual::mouseRightRelease, this));
 }
 
+void ChassisGimbalShooterManual::xPress()
+{
+}
+
+void ChassisGimbalShooterManual::xReleasing()
+{
+}
 void ChassisGimbalShooterManual::run()
 {
   ChassisGimbalManual::run();

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -11,7 +11,8 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
 {
   ros::NodeHandle shooter_nh(nh, "shooter");
   shooter_cmd_sender_ = new rm_common::ShooterCommandSender(shooter_nh);
-
+  ros::NodeHandle camera_nh(nh, "camera");
+  camera_switch_cmd_sender_ = new rm_common::CameraSwitchCommandSender(camera_nh);
   ros::NodeHandle detection_switch_nh(nh, "detection_switch");
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
   XmlRpc::XmlRpcValue rpc_value;

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -11,8 +11,11 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
 {
   ros::NodeHandle shooter_nh(nh, "shooter");
   shooter_cmd_sender_ = new rm_common::ShooterCommandSender(shooter_nh);
-  ros::NodeHandle camera_nh(nh, "camera");
-  camera_switch_cmd_sender_ = new rm_common::CameraSwitchCommandSender(camera_nh);
+  if (nh.hasParam("camera"))
+  {
+    ros::NodeHandle camera_nh(nh, "camera");
+    camera_switch_cmd_sender_ = new rm_common::CameraSwitchCommandSender(camera_nh);
+  }
   ros::NodeHandle detection_switch_nh(nh, "detection_switch");
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
   XmlRpc::XmlRpcValue rpc_value;

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -16,6 +16,7 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
     ros::NodeHandle camera_nh(nh, "camera");
     camera_switch_cmd_sender_ = new rm_common::CameraSwitchCommandSender(camera_nh);
   }
+
   ros::NodeHandle detection_switch_nh(nh, "detection_switch");
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
   XmlRpc::XmlRpcValue rpc_value;

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -72,6 +72,7 @@ void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr
   f_event_.update(dbus_data->key_f);
   b_event_.update((!dbus_data->key_ctrl && !dbus_data->key_shift) & dbus_data->key_b);
   x_event_.update(dbus_data->key_x);
+  r_event_.update((!dbus_data->key_ctrl) & dbus_data->key_r);
   ctrl_c_event_.update(dbus_data->key_ctrl & dbus_data->key_c);
   ctrl_v_event_.update(dbus_data->key_ctrl & dbus_data->key_v);
   ctrl_r_event_.update(dbus_data->key_ctrl & dbus_data->key_r);
@@ -125,6 +126,7 @@ void ChassisGimbalShooterManual::sendCommand(const ros::Time& time)
 {
   ChassisGimbalManual::sendCommand(time);
   shooter_cmd_sender_->sendCommand(time);
+  camera_switch_cmd_sender_->sendCommand(time);
 }
 
 void ChassisGimbalShooterManual::remoteControlTurnOff()
@@ -340,6 +342,11 @@ void ChassisGimbalShooterManual::wPress()
     chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
     chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
   }
+}
+
+void ChassisGimbalShooterManual::rPress()
+{
+  camera_switch_cmd_sender_->switchCamera();
 }
 
 void ChassisGimbalShooterManual::aPress()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -28,6 +28,9 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   q_event_.setRising(boost::bind(&ChassisGimbalShooterManual::qPress, this));
   f_event_.setRising(boost::bind(&ChassisGimbalShooterManual::fPress, this));
   b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::bPress, this));
+  x_event_.setRising(boost::bind(&ChassisGimbalShooterManual::xPress, this));
+  x_event_.setActiveLow(boost::bind(&ChassisGimbalShooterManual::xReleasing, this));
+  r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::rPress, this));
   ctrl_c_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlCPress, this));
   ctrl_v_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlVPress, this));
   ctrl_r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlRPress, this));

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -336,6 +336,12 @@ void ChassisGimbalShooterManual::bPress()
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
 }
 
+void ChassisGimbalShooterManual::rPress()
+{
+  if (camera_switch_cmd_sender_)
+    camera_switch_cmd_sender_->switchCamera();
+}
+
 void ChassisGimbalShooterManual::wPress()
 {
   ChassisGimbalManual::wPress();
@@ -347,11 +353,6 @@ void ChassisGimbalShooterManual::wPress()
     chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
     chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
   }
-}
-
-void ChassisGimbalShooterManual::rPress()
-{
-  camera_switch_cmd_sender_->switchCamera();
 }
 
 void ChassisGimbalShooterManual::aPress()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -429,7 +429,7 @@ void EngineerManual::ctrlDPress()
 {
   prefix_ = "";
   root_ = "GROUND_STONE0";
-  runStepQueue(root_);
+  runStepQueue(prefix_ + root_);
   ROS_INFO("%s", (prefix_ + root_).c_str());
 }
 
@@ -437,7 +437,7 @@ void EngineerManual::ctrlFPress()
 {
   prefix_ = "";
   root_ = "EXCHANGE_WAIT";
-  runStepQueue(root_);
+  runStepQueue(prefix_ + root_);
   ROS_INFO("%s", (prefix_ + root_).c_str());
 }
 
@@ -458,8 +458,8 @@ void EngineerManual::ctrlGPress()
       root_ = "STORE_WHEN_TWO_STONE0";
       break;
   }
-  runStepQueue(root_);
   prefix_ = "";
+  runStepQueue(prefix_ + root_);
   ROS_INFO("STORE_STONE");
 }
 
@@ -687,7 +687,7 @@ void EngineerManual::shiftCPress()
 {
   prefix_ = "";
   root_ = "EXCHANGE_CONTINUE";
-  runStepQueue(root_);
+  runStepQueue(prefix_ + root_);
 }
 void EngineerManual::shiftZPress()
 {
@@ -744,7 +744,7 @@ void EngineerManual::shiftGPress()
       break;
   }
   prefix_ = "";
-  runStepQueue(root_);
+  runStepQueue(prefix_ + root_);
 
   ROS_INFO("TAKE_STONE");
 }

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -265,6 +265,8 @@ void EngineerManual::rightSwitchUpRise()
 
 void EngineerManual::leftSwitchUpRise()
 {
+  prefix_ = "";
+  root_ = "CALIBRATION";
   calibration_gather_->reset();
   runStepQueue("CLOSE_GRIPPER");
 }
@@ -404,8 +406,9 @@ void EngineerManual::ctrlEPress()
 
 void EngineerManual::ctrlRPress()
 {
+  prefix_ = "";
+  root_ = "calibration";
   calibration_gather_->reset();
-  engineer_ui_.current_step_name = "calibration";
   ROS_INFO("Calibrated");
   runStepQueue("CLOSE_GRIPPER");
 }

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -401,8 +401,9 @@ void EngineerManual::mouseRightRelease()
 }
 void EngineerManual::ctrlQPress()
 {
-  prefix_ = "LF_";
+  prefix_ = "NEW_LF_";
   root_ = "SMALL_ISLAND";
+  runStepQueue("NEW_LF_SMALL_ISLAND");
   ROS_INFO("%s", (prefix_ + root_).c_str());
 }
 
@@ -415,8 +416,9 @@ void EngineerManual::ctrlWPress()
 
 void EngineerManual::ctrlEPress()
 {
-  prefix_ = "RT_";
+  prefix_ = "NEW_RT_";
   root_ = "SMALL_ISLAND";
+  runStepQueue("NEW_RT_SMALL_ISLAND");
   ROS_INFO("%s", (prefix_ + root_).c_str());
 }
 
@@ -434,8 +436,8 @@ void EngineerManual::ctrlRPress()
 void EngineerManual::ctrlAPress()
 {
   prefix_ = "";
-  root_ = "SMALL_ISLAND";
-  runStepQueue("SMALL_ISLAND");
+  root_ = "NEW_SMALL_ISLAND";
+  runStepQueue("NEW_SMALL_ISLAND");
   ROS_INFO("%s", (prefix_ + root_).c_str());
 }
 

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -595,9 +595,9 @@ void EngineerManual::rPress()
 
 void EngineerManual::xPress()
 {
-  if (root_ != "DRAG_CAR")
+  if (prefix_ != "ENGINEER_")
   {
-    prefix_ = "";
+    prefix_ = "ENGINEER_";
     root_ = "DRAG_CAR";
   }
   else

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -11,7 +11,6 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   , operating_mode_(MANUAL)
   , action_client_("/engineer_middleware/move_steps", true)
 {
-  exchange_sub_ = nh.subscribe<rm_msgs::ExchangerMsg>("/pnp_publisher", 10, &EngineerManual::exchangeCallback, this);
   ROS_INFO("Waiting for middleware to start.");
   action_client_.waitForServer();
   ROS_INFO("Middleware started.");
@@ -22,6 +21,7 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   if (!vel_nh.getParam("gyro_low_scale", gyro_low_scale_))
     gyro_low_scale_ = 0.05;
   // Ui
+  exchange_sub_ = nh.subscribe<rm_msgs::ExchangerMsg>("/pnp_publisher", 10, &EngineerManual::exchangeCallback, this);
   engineer_ui_pub_ = nh.advertise<rm_msgs::EngineerUi>("/engineer_ui", 10);
   // Drag
   ros::NodeHandle nh_drag(nh, "drag");

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -189,8 +189,8 @@ void EngineerManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
   left_switch_up_event_.update(dbus_data->s_l == rm_msgs::DbusData::UP);
   chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::RAW);
   if (!reversal_motion_ && servo_mode_ == JOINT)
-    reversal_command_sender_->setGroupVel(0., 0., 5 * dbus_data->ch_r_y, 5 * dbus_data->ch_l_x, 5 * dbus_data->ch_l_y,
-                                          0.);
+    reversal_command_sender_->setGroupValue(0., 0., 5 * dbus_data->ch_r_y, 5 * dbus_data->ch_l_x, 5 * dbus_data->ch_l_y,
+                                            0.);
 }
 
 void EngineerManual::sendCommand(const ros::Time& time)
@@ -267,14 +267,13 @@ void EngineerManual::leftSwitchUpRise()
   prefix_ = "";
   root_ = "CALIBRATION";
   calibration_gather_->reset();
-  runStepQueue("OPEN_GRIPPER");
+  EngineerManual::ctrlVPress();
   ROS_INFO_STREAM("START CALIBRATE");
 }
 
 void EngineerManual::leftSwitchDownFall()
 {
   runStepQueue("HOME_ONE_STONE");
-  runStepQueue("CLOSE_GRIPPER");
   drag_command_sender_->on();
   drag_state_ = "on";
 }
@@ -618,7 +617,7 @@ void EngineerManual::bPressing()
 {
   // ROLL
   reversal_motion_ = true;
-  reversal_command_sender_->setGroupVel(0., 0., 0., 1., 0., 0.);
+  reversal_command_sender_->setGroupValue(0., 0., 0., 1., 0., 0.);
   reversal_state_ = "ROLL";
 }
 
@@ -656,7 +655,7 @@ void EngineerManual::vPressing()
 {
   // Z in
   reversal_motion_ = true;
-  reversal_command_sender_->setGroupVel(0., 0., -1., 0., 0., 0.);
+  reversal_command_sender_->setGroupValue(0., 0., -1., 0., 0., 0.);
   reversal_state_ = "Z IN";
 }
 void EngineerManual::fPress()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -233,7 +233,6 @@ void EngineerManual::remoteControlTurnOff()
 
 void EngineerManual::chassisOutputOn()
 {
-  calibration_gather_->reset();
   if (MIDDLEWARE)
     action_client_.cancelAllGoals();
 }
@@ -314,7 +313,6 @@ void EngineerManual::actionDoneCallback(const actionlib::SimpleClientGoalState& 
   ROS_INFO("Finished in state [%s]", state.toString().c_str());
   ROS_INFO("Result: %i", result->finish);
   ROS_INFO("Done %s", (prefix_ + root_).c_str());
-  engineer_ui_.current_step_name += " done!";
   if (prefix_ + root_ == "TAKE_WHEN_TWO_STONE00" || prefix_ + root_ == "TAKE_WHEN_ONE_STONE00" ||
       prefix_ + root_ == "TAKE_WHEN_THREE_STONE00")
   {
@@ -407,7 +405,7 @@ void EngineerManual::ctrlEPress()
 void EngineerManual::ctrlRPress()
 {
   prefix_ = "";
-  root_ = "calibration";
+  root_ = "CALIBRATION";
   calibration_gather_->reset();
   ROS_INFO("Calibrated");
   runStepQueue("CLOSE_GRIPPER");
@@ -509,24 +507,15 @@ void EngineerManual::ctrlCPress()
   runStepQueue("DELETE_SCENE");
   action_client_.cancelAllGoals();
   prefix_ = "";
-  root_ = "";
-  engineer_ui_.current_step_name = "cancel";
+  root_ = "CANCEL GOALS";
 }
 
 void EngineerManual::ctrlVPress()
 {
-  root_ = "";
-  prefix_ = "";
   if (gripper_state_ == "open")
-  {
     runStepQueue("CLOSE_GRIPPER");
-    engineer_ui_.current_step_name = "CLOSE_GRIPPER";
-  }
   else
-  {
     runStepQueue("OPEN_GRIPPER");
-    engineer_ui_.current_step_name = "OPEN_GRIPPER";
-  }
 }
 
 void EngineerManual::ctrlVRelease()
@@ -552,7 +541,7 @@ void EngineerManual::ctrlBPress()
   }
   ROS_INFO("RUN_HOME");
   prefix_ = "";
-  runStepQueue(root_);
+  runStepQueue(prefix_ + root_);
 }
 
 void EngineerManual::qPressing()
@@ -607,7 +596,7 @@ void EngineerManual::xPress()
 {
   prefix_ = "";
   root_ = "DRAG_CAR0";
-  runStepQueue(root_);
+  runStepQueue(prefix_ + root_);
   if (drag_state_ == "on")
   {
     drag_command_sender_->off();

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -212,15 +212,6 @@ void EngineerManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
   if (!reversal_motion_ && servo_mode_ == JOINT)
     reversal_command_sender_->setGroupValue(0., 0., 5 * dbus_data->ch_r_y, 5 * dbus_data->ch_l_x, 5 * dbus_data->ch_l_y,
                                             0.);
-  if (is_auxiliary_camera_)
-  {
-    //    chassis_cmd_sender_->getMsg()->follow_source_frame = base_link;
-    //    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-  }
-  else
-  {
-    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::RAW);
-  }
 }
 
 void EngineerManual::sendCommand(const ros::Time& time)
@@ -240,7 +231,6 @@ void EngineerManual::sendCommand(const ros::Time& time)
   }
   if (gimbal_mode_ == RATE)
     gimbal_cmd_sender_->sendCommand(time);
-  // judgeJoint7(time);
 }
 
 void EngineerManual::updateServo(const rm_msgs::DbusData::ConstPtr& dbus_data)
@@ -368,19 +358,6 @@ void EngineerManual::sendUi()
   engineer_ui_.joint_temperature = joint_temperature_;
   engineer_ui_.gripper_state = gripper_state_;
   engineer_ui_pub_.publish(engineer_ui_);
-}
-
-void EngineerManual::judgeJoint7(const ros::Time& time)
-{
-  if (prefix_ + root_ == "GROUND_STONE0" || prefix_ == "EXCHANGE_" || prefix_ + root_ == "GROUND_STONE00")
-  {
-    joint7_command_sender_->off();
-  }
-  else
-  {
-    joint7_command_sender_->on();
-  }
-  joint7_command_sender_->sendCommand(time);
 }
 
 void EngineerManual::mouseLeftRelease()
@@ -520,8 +497,6 @@ void EngineerManual::ctrlZRelease()
 
 void EngineerManual::ctrlXPress()
 {
-  //  prefix_ = "THREE_STONE_";
-  //  root_ = "SMALL_ISLAND";
   prefix_ = "";
   root_ = "NEW_THREE_STONE_SMALL_ISLAND";
   runStepQueue("NEW_THREE_STONE_SMALL_ISLAND");
@@ -705,16 +680,15 @@ void EngineerManual::shiftRelease()
 }
 void EngineerManual::shiftFPress()
 {
-  //  prefix_ = "";
-  //  root_ = "EXCHANGE_GIMBAL";
   runStepQueue("EXCHANGE_GIMBAL");
+  if (servo_mode_ == SERVO)
+    chassis_cmd_sender_->changeCommandSourceFrame("fake_link5");
+  else
+    chassis_cmd_sender_->changeCommandSourceFrame("base_link");
   ROS_INFO("enter gimbal EXCHANGE_GIMBAL");
 }
 void EngineerManual::shiftRPress()
 {
-  //  prefix_ = "";
-  //  root_ = "SKY_GIMBAL";
-  //  runStepQueue(prefix_ + root_);
   runStepQueue("SKY_GIMBAL");
   ROS_INFO("enter gimbal SKY_GIMBAL");
 }
@@ -733,10 +707,8 @@ void EngineerManual::shiftCPress()
 }
 void EngineerManual::shiftZPress()
 {
-  //  prefix_ = "";
-  //  root_ = "ISLAND_GIMBAL";
-  //  runStepQueue(prefix_ + root_);
   runStepQueue("ISLAND_GIMBAL");
+  chassis_cmd_sender_->changeCommandSourceFrame("yaw");
   ROS_INFO("enter gimbal REVERSAL_GIMBAL");
 }
 void EngineerManual::shiftVPress()
@@ -757,10 +729,8 @@ void EngineerManual::shiftVRelease()
 
 void EngineerManual::shiftBPress()
 {
-  //  prefix_ = "";
-  //  root_ = "SIDE_GIMBAL";
-  //  runStepQueue(prefix_ + root_);
   runStepQueue("SIDE_GIMBAL");
+  chassis_cmd_sender_->changeCommandSourceFrame("yaw");
   ROS_INFO("enter gimbal BACK_GIMBAL");
 }
 
@@ -771,6 +741,7 @@ void EngineerManual::shiftBRelease()
 void EngineerManual::shiftXPress()
 {
   runStepQueue("GROUND_GIMBAL");
+  chassis_cmd_sender_->changeCommandSourceFrame("yaw");
   ROS_INFO("enter gimbal GROUND_GIMBAL");
 }
 

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -89,7 +89,7 @@ void EngineerManual::run()
 {
   ChassisGimbalManual::run();
   calibration_gather_->update(ros::Time::now());
-  sendUi(prefix_ + root_, reversal_state_, drag_state_, stone_num_, joint_temperature_, gripper_state_);
+  sendUi();
 }
 
 void EngineerManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)
@@ -329,43 +329,15 @@ void EngineerManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPt
   }
 }
 
-void EngineerManual::updateUiDate(std::string step_name, std::string reversal_state, std::string drag_state,
-                                  uint8_t stone_num, std::string joint_temperature, std::string gripper_state)
+void EngineerManual::sendUi()
 {
-  engineer_ui_.current_step_name = step_name;
-  engineer_ui_.reversal_state = reversal_state;
-  engineer_ui_.drag_state = drag_state;
-  engineer_ui_.stone_num = stone_num;
-  engineer_ui_.joint_temperature = joint_temperature;
-  engineer_ui_.gripper_state = gripper_state;
-
-  step_name_last_ = step_name;
-  reversal_state_last_ = reversal_state;
-  drag_state_last_ = drag_state;
-  stone_num_last_ = stone_num;
-  joint_temperature_last_ = joint_temperature;
-  gripper_state_last_ = gripper_state;
-}
-
-bool EngineerManual::judgeUiChange(std::string step_name, std::string reversal_state, std::string drag_state,
-                                   uint8_t stone_num, std::string joint_temperature, std::string gripper_state)
-{
-  if (step_name != step_name_last_ || reversal_state != reversal_state_last_ || drag_state != drag_state_last_ ||
-      stone_num != stone_num_last_ || joint_temperature != joint_temperature_last_ ||
-      gripper_state != gripper_state_last_)
-  {
-    updateUiDate(step_name, reversal_state, drag_state, stone_num, joint_temperature, gripper_state);
-    return true;
-  }
-  else
-    return false;
-}
-
-void EngineerManual::sendUi(std::string step_name, std::string reversal_state, std::string drag_state,
-                            uint8_t stone_num, std::string joint_temperature, std::string gripper_state)
-{
-  if (judgeUiChange(step_name, reversal_state, drag_state, stone_num, joint_temperature, gripper_state))
-    ui_send_.publish(engineer_ui_);
+  engineer_ui_.current_step_name = prefix_ + root_;
+  engineer_ui_.reversal_state = reversal_state_;
+  engineer_ui_.drag_state = drag_state_;
+  engineer_ui_.stone_num = stone_num_;
+  engineer_ui_.joint_temperature = joint_temperature_;
+  engineer_ui_.gripper_state = gripper_state_;
+  ui_send_.publish(engineer_ui_);
 }
 
 void EngineerManual::mouseLeftRelease()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -22,7 +22,7 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   if (!vel_nh.getParam("gyro_low_scale", gyro_low_scale_))
     gyro_low_scale_ = 0.05;
   // Ui
-  ui_send_ = nh.advertise<rm_msgs::EngineerUi>("/engineer_ui", 10);
+  engineer_ui_pub_ = nh.advertise<rm_msgs::EngineerUi>("/engineer_ui", 10);
   // Drag
   ros::NodeHandle nh_drag(nh, "drag");
   drag_command_sender_ = new rm_common::JointPositionBinaryCommandSender(nh_drag);
@@ -362,7 +362,7 @@ void EngineerManual::sendUi()
   engineer_ui_.stone_num = stone_num_;
   engineer_ui_.joint_temperature = joint_temperature_;
   engineer_ui_.gripper_state = gripper_state_;
-  ui_send_.publish(engineer_ui_);
+  engineer_ui_pub_.publish(engineer_ui_);
 }
 
 void EngineerManual::mouseLeftRelease()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -30,7 +30,7 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   // Calibration
   XmlRpc::XmlRpcValue rpc_value;
   nh.getParam("calibration_gather", rpc_value);
-  calibration_gather = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
+  calibration_gather_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
   left_switch_up_event_.setFalling(boost::bind(&EngineerManual::leftSwitchUpFall, this));
   left_switch_up_event_.setRising(boost::bind(&EngineerManual::leftSwitchUpRise, this));
   left_switch_down_event_.setFalling(boost::bind(&EngineerManual::leftSwitchDownFall, this));
@@ -88,7 +88,7 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
 void EngineerManual::run()
 {
   ChassisGimbalManual::run();
-  calibration_gather->update(ros::Time::now(), state_ != PASSIVE);
+  calibration_gather_->update(ros::Time::now(), state_ != PASSIVE);
   sendUi(prefix_ + root_, reversal_state_, drag_state_, stone_num_, joint_temperature_, gripper_state_);
 }
 
@@ -239,7 +239,7 @@ void EngineerManual::rightSwitchUpRise()
 
 void EngineerManual::leftSwitchUpRise()
 {
-  calibration_gather->reset();
+  calibration_gather_->reset();
   runStepQueue("CLOSE_GRIPPER");
   gripper_state_ = "close";
 }
@@ -405,7 +405,7 @@ void EngineerManual::ctrlEPress()
 
 void EngineerManual::ctrlRPress()
 {
-  calibration_gather->reset();
+  calibration_gather_->reset();
   engineer_ui_.current_step_name = "calibration";
   ROS_INFO("Calibrated");
 }

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -469,7 +469,9 @@ void EngineerManual::ctrlZPress()
 {
   if (is_exchange_)
   {
-    runStepQueue("GENERATE_EXCHANGE");
+    prefix_ = "";
+    root_ = "GENERATE_EXCHANGE";
+    runStepQueue(prefix_ + root_);
     action_client_.cancelAllGoals();
   }
 }
@@ -478,7 +480,9 @@ void EngineerManual::ctrlZPressing()
 {
   if (is_exchange_)
   {
-    runStepQueue("GENERATE_EXCHANGE");
+    prefix_ = "";
+    root_ = "GENERATE_EXCHANGE";
+    runStepQueue(prefix_ + root_);
     action_client_.cancelAllGoals();
   }
 }
@@ -486,7 +490,11 @@ void EngineerManual::ctrlZPressing()
 void EngineerManual::ctrlZRelease()
 {
   if (is_exchange_)
-    runStepQueue("AUTO_EXCHANGER");
+  {
+    prefix_ = "";
+    root_ = "AUTO_EXCHANGER";
+    runStepQueue(prefix_ + root_);
+  }
 }
 
 void EngineerManual::ctrlXPress()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -13,7 +13,7 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
 {
   exchange_sub_ = nh.subscribe<rm_msgs::ExchangerMsg>("/pnp_publisher", 10, &EngineerManual::exchangeCallback, this);
   ROS_INFO("Waiting for middleware to start.");
-  //  action_client_.waitForServer();
+  action_client_.waitForServer();
   ROS_INFO("Middleware started.");
   // UI
   ui_send_ = nh.advertise<rm_msgs::EngineerUi>("/engineer_ui", 10);
@@ -245,17 +245,17 @@ void EngineerManual::leftSwitchUpRise()
 {
   arm_calibration_->reset();
   power_on_calibration_->reset();
-  runStepQueue("OPEN_GRIPPER");
-  gripper_state_ = "on";
+  runStepQueue("CLOSE_GRIPPER");
+  gripper_state_ = "close";
 }
 
 void EngineerManual::leftSwitchDownFall()
 {
   runStepQueue("HOME_ONE_STONE");
-  runStepQueue("OPEN_GRIPPER");
+  runStepQueue("CLOSE_GRIPPER");
   drag_command_sender_->on();
   drag_state_ = "on";
-  gripper_state_ = "on";
+  gripper_state_ = "off";
 }
 
 void EngineerManual::leftSwitchUpFall()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -268,6 +268,7 @@ void EngineerManual::leftSwitchUpRise()
   root_ = "CALIBRATION";
   calibration_gather_->reset();
   runStepQueue("CLOSE_GRIPPER");
+  ROS_INFO_STREAM("START CALIBRATE");
 }
 
 void EngineerManual::leftSwitchDownFall()
@@ -407,8 +408,8 @@ void EngineerManual::ctrlRPress()
   prefix_ = "";
   root_ = "CALIBRATION";
   calibration_gather_->reset();
-  ROS_INFO("Calibrated");
   runStepQueue("CLOSE_GRIPPER");
+  ROS_INFO_STREAM("START CALIBRATE");
 }
 
 void EngineerManual::ctrlAPress()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -595,18 +595,23 @@ void EngineerManual::rPress()
 
 void EngineerManual::xPress()
 {
-  prefix_ = "";
-  root_ = "DRAG_CAR0";
-  runStepQueue(prefix_ + root_);
-  if (drag_state_ == "on")
+  if (root_ != "DRAG_CAR")
   {
-    drag_command_sender_->off();
-    drag_state_ = "off";
+    prefix_ = "";
+    root_ = "DRAG_CAR";
   }
   else
   {
-    drag_command_sender_->on();
-    drag_state_ = "on";
+    if (drag_state_ == "on")
+    {
+      drag_command_sender_->off();
+      drag_state_ = "off";
+    }
+    else
+    {
+      drag_command_sender_->on();
+      drag_state_ = "on";
+    }
   }
 }
 void EngineerManual::bPressing()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -104,7 +104,6 @@ void EngineerManual::run()
 {
   ChassisGimbalManual::run();
   calibration_gather_->update(ros::Time::now());
-  joint5_calibration_->update(ros::Time::now());
   sendUi();
 }
 
@@ -172,6 +171,7 @@ void EngineerManual::exchangeCallback(const rm_msgs::ExchangerMsg ::ConstPtr& da
 
 void EngineerManual::stoneNumCallback(const std_msgs::String ::ConstPtr& data)
 {
+  std::cout << stone_num_ << std::endl;
   if (data->data == "-1")
     stone_num_ -= 1;
   else if (data->data == "+1")
@@ -294,7 +294,7 @@ void EngineerManual::leftSwitchUpRise()
 
 void EngineerManual::leftSwitchDownFall()
 {
-  runStepQueue("HOME_ONE_STONE");
+  //  runStepQueue("HOME_ONE_STONE");
   drag_command_sender_->on();
   drag_state_ = "on";
 }

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -267,7 +267,7 @@ void EngineerManual::leftSwitchUpRise()
   prefix_ = "";
   root_ = "CALIBRATION";
   calibration_gather_->reset();
-  runStepQueue("CLOSE_GRIPPER");
+  runStepQueue("OPEN_GRIPPER");
   ROS_INFO_STREAM("START CALIBRATE");
 }
 

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -208,6 +208,7 @@ void EngineerManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
   ChassisGimbalManual::updatePc(dbus_data);
   left_switch_up_event_.update(dbus_data->s_l == rm_msgs::DbusData::UP);
   chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::RAW);
+  //  gimbal_cmd_sender_->setRate(-dbus_data->m_x * gimbal_scale_, dbus_data->m_y * gimbal_scale_);
   if (!reversal_motion_ && servo_mode_ == JOINT)
     reversal_command_sender_->setGroupValue(0., 0., 5 * dbus_data->ch_r_y, 5 * dbus_data->ch_l_x, 5 * dbus_data->ch_l_y,
                                             0.);
@@ -232,7 +233,11 @@ void EngineerManual::sendCommand(const ros::Time& time)
     drag_command_sender_->sendCommand(time);
   }
   if (servo_mode_ == SERVO)
+  {
     servo_command_sender_->sendCommand(time);
+    prefix_ = "";
+    root_ = "";
+  }
   if (gimbal_mode_ == RATE)
     gimbal_cmd_sender_->sendCommand(time);
   // judgeJoint7(time);
@@ -294,7 +299,7 @@ void EngineerManual::leftSwitchUpRise()
 
 void EngineerManual::leftSwitchDownFall()
 {
-  //  runStepQueue("HOME_ONE_STONE");
+  runStepQueue("HOME_ZERO_STONE");
   drag_command_sender_->on();
   drag_state_ = "on";
 }
@@ -517,7 +522,7 @@ void EngineerManual::ctrlXPress()
   //  root_ = "SMALL_ISLAND";
   prefix_ = "";
   root_ = "NEW_THREE_STONE_SMALL_ISLAND";
-  runStepQueue("THREE_STONE_SMALL_ISLAND");
+  runStepQueue("NEW_THREE_STONE_SMALL_ISLAND");
   ROS_INFO("%s", (prefix_ + root_).c_str());
 }
 
@@ -525,8 +530,6 @@ void EngineerManual::ctrlCPress()
 {
   runStepQueue("DELETE_SCENE");
   action_client_.cancelAllGoals();
-  prefix_ = "";
-  root_ = "CANCEL GOALS";
 }
 
 void EngineerManual::ctrlVPress()
@@ -675,7 +678,7 @@ void EngineerManual::vPressing()
 {
   // Z in
   reversal_motion_ = true;
-  reversal_command_sender_->setGroupValue(0., 0., -1., 0., 0., 0.);
+  reversal_command_sender_->setGroupValue(0., 0., -3., 0., 0., 0.);
   reversal_state_ = "Z IN";
 }
 void EngineerManual::fPress()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -332,6 +332,7 @@ void EngineerManual::actionDoneCallback(const actionlib::SimpleClientGoalState& 
 
 void EngineerManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)
 {
+  max_temperature_ = data->temperature[0];
   for (std::vector<int>::size_type i = 0; i < data->id.size(); ++i)
   {
     if (data->temperature[i] > max_temperature_)
@@ -680,19 +681,9 @@ void EngineerManual::shiftRPress()
 }
 void EngineerManual::shiftCPress()
 {
-  if (servo_mode_ == true)
-  {
-    servo_mode_ = false;
-    engineer_ui_.current_step_name = "ENTER servo";
-    ROS_INFO("EXIT SERVO");
-  }
-  else
-  {
-    servo_mode_ = 1;
-    engineer_ui_.current_step_name = "exit SERVO";
-    ROS_INFO("ENTER SERVO");
-  }
-  ROS_INFO("cancel all goal");
+  prefix_ = "";
+  root_ = "EXCHANGE_CONTINUE";
+  runStepQueue(root_);
 }
 void EngineerManual::shiftZPress()
 {

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -15,7 +15,13 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   ROS_INFO("Waiting for middleware to start.");
   action_client_.waitForServer();
   ROS_INFO("Middleware started.");
-  // UI
+  // Vel
+  ros::NodeHandle vel_nh(nh, "vel");
+  if (!vel_nh.getParam("gyro_scale", gyro_scale_))
+    gyro_scale_ = 0.5;
+  if (!vel_nh.getParam("gyro_low_scale", gyro_low_scale_))
+    gyro_low_scale_ = 0.05;
+  // Ui
   ui_send_ = nh.advertise<rm_msgs::EngineerUi>("/engineer_ui", 10);
   // Drag
   ros::NodeHandle nh_drag(nh, "drag");
@@ -529,10 +535,7 @@ void EngineerManual::ctrlBPress()
 
 void EngineerManual::qPressing()
 {
-  if (speed_change_mode_ == true)
-    vel_cmd_sender_->setAngularZVel(0.05);
-  else
-    vel_cmd_sender_->setAngularZVel(0.5);
+  vel_cmd_sender_->setAngularZVel(speed_change_mode_ ? gyro_low_scale_ : gyro_scale_);
 }
 
 void EngineerManual::qRelease()
@@ -542,10 +545,7 @@ void EngineerManual::qRelease()
 
 void EngineerManual::ePressing()
 {
-  if (speed_change_mode_ == true)
-    vel_cmd_sender_->setAngularZVel(-0.05);
-  else
-    vel_cmd_sender_->setAngularZVel(-0.5);
+  vel_cmd_sender_->setAngularZVel(speed_change_mode_ ? -gyro_low_scale_ : -gyro_scale_);
 }
 
 void EngineerManual::eRelease()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -88,7 +88,7 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
 void EngineerManual::run()
 {
   ChassisGimbalManual::run();
-  calibration_gather_->update(ros::Time::now(), state_ != PASSIVE);
+  calibration_gather_->update(ros::Time::now());
   sendUi(prefix_ + root_, reversal_state_, drag_state_, stone_num_, joint_temperature_, gripper_state_);
 }
 
@@ -264,6 +264,7 @@ void EngineerManual::leftSwitchDownRise()
 void EngineerManual::runStepQueue(const std::string& step_queue_name)
 {
   rm_msgs::EngineerGoal goal;
+  reversal_motion_ = 1;
   goal.step_queue_name = step_queue_name;
   if (action_client_.isServerConnected())
   {
@@ -312,6 +313,7 @@ void EngineerManual::actionDoneCallback(const actionlib::SimpleClientGoalState& 
     stone_num_ = 3;
   }
   operating_mode_ = MANUAL;
+  reversal_motion_ = 0;
 }
 
 void EngineerManual::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& data)

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -12,7 +12,6 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   , action_client_("/engineer_middleware/move_steps", true)
 {
   exchange_sub_ = nh.subscribe<rm_msgs::ExchangerMsg>("/pnp_publisher", 10, &EngineerManual::exchangeCallback, this);
-  step_queue_state_pub_ = nh.advertise<rm_msgs::StepQueueState>("/step_queue_state", 10);
   ROS_INFO("Waiting for middleware to start.");
   //  action_client_.waitForServer();
   ROS_INFO("Middleware started.");
@@ -254,6 +253,8 @@ void EngineerManual::leftSwitchDownFall()
 {
   runStepQueue("HOME_ONE_STONE");
   runStepQueue("OPEN_GRIPPER");
+  drag_command_sender_->on();
+  drag_state_ = "on";
   gripper_state_ = "on";
 }
 
@@ -283,8 +284,6 @@ void EngineerManual::runStepQueue(const std::string& step_queue_name)
 
 void EngineerManual::actionFeedbackCallback(const rm_msgs::EngineerFeedbackConstPtr& feedback)
 {
-  step_queue_state_.current_step_name = feedback->current_step;
-  step_queue_state_.total_steps = feedback->total_steps;
 }
 
 void EngineerManual::actionDoneCallback(const actionlib::SimpleClientGoalState& state,

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -495,6 +495,7 @@ void EngineerManual::ctrlXPress()
 
 void EngineerManual::ctrlCPress()
 {
+  runStepQueue("DELETE_SCENE");
   action_client_.cancelAllGoals();
   prefix_ = "";
   root_ = "";


### PR DESCRIPTION
# 2023工程manual整合

## 功能包括

- 和engineer_middleware的交互（主要为机械臂部分）
- 机械臂伺服控制
- 机械臂和视觉的交互
- 和referee的交互（ui）
- 拖拽，翻转，云台，底盘控制

## 主要的更改

- 完善了UI显示的部分
- 增加翻转部分
- 引入了视觉兑换
- 更具新的规则简化了按键逻辑

## 动作键位分配

#### 总共14个字母键，两个功能键，两个鼠标键，遥控器两个拨杆两个摇杆一个滚轮

| 字母 | 功能                       | 字母 | 功能                                            | 字母 | 功能                      | 字母 | 功能                       | 字母 | 功能                        |
| ---- | -------------------------- | ---- | ----------------------------------------------- | ---- | ------------------------- | ---- | -------------------------- | ---- | --------------------------- |
| Q    | 左转                       | W    | 前                                              | E    | 右转                      | R    | 矿石数量切换               |      |                             |
| A    | 左                         | S    | 后                                              | D    | 右                        | F    | 翻转升（按下作用松开停）   | G    | 翻转降（按下作用松开停）    |
| Z    | server z（按下作用松开停） | X    | 拖拽,微抬（用于抬障碍快）和平放（按下切换状态） | C    | serverz（按下作用松开停） | V    | 翻转ROLL（按下作用松开停） | B    | 翻转PITCH（按下作用松开停） |

### +ctrl

| 字母 | 功能                                            | 字母 | 功能                 | 字母 | 功能                                                         | 字母 | 功能                     | 字母 | 功能                                           |
| ---- | ----------------------------------------------- | ---- | -------------------- | ---- | ------------------------------------------------------------ | ---- | ------------------------ | ---- | ---------------------------------------------- |
| Q    | 左_小资源岛取矿                                 | W    | 大资源岛空接         | E    | 右_小资源岛取矿                                              | R    | 校准                     |      |                                                |
| A    | 小资源岛取矿                                    | S    | 大资源岛取矿（中间） | D    | 取地面矿石（拖拽会在微抬状态）                               | F    | 兑换预备姿势（方便伺服） | G    | 存矿（不需要考虑自身矿石数量）                 |
| Z    | 拖拽,微抬（用于抬障碍快）和平放（按下切换状态） | X    | 连取                 | C    | 取消下一个动作（如果STEP的UI显示的动作和自己想做的动作不一样就按） | V    | 吸盘（按下切换状态）     | B    | 机械臂做完动作HOME状态（不需要考虑自身矿石数量 |

### +shift（快速/取消/云台）

| 字母 | 功能     | 字母 | 功能                                                         | 字母 | 功能             | 字母 | 功能                                                         | 字母 | 功能                           |
| ---- | -------- | ---- | ------------------------------------------------------------ | ---- | ---------------- | ---- | ------------------------------------------------------------ | ---- | ------------------------------ |
| Q    | 慢左转   | W    | 快前                                                         | E    | 慢右转           | R    | 云台大资源岛空接（空接时候用）（==UI说明：中间的黄色矿是空接矿==） |      |                                |
| A    | 快左     | S    | 快后                                                         | D    | 慢右             | F    | 云台度兑换                                                   | G    | 取矿（不需要考虑自身矿石数量） |
| Z    | 云台翻转 | X    | 云台地面（在大资源岛和地面矿时候用）（==UI说明：大的梯形是地面矿，中间小梯形是大资源岛矿==） | C    | 进入退出伺服模式 | V    | 云台随鼠标动                                                 | B    | 云台反转（回家时候用）         |
