### PR TITLE
Determine whether to construct a camera switch command sender based on whether there are parameters

### DIFF
--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -11,8 +11,11 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
 {
   ros::NodeHandle shooter_nh(nh, "shooter");
   shooter_cmd_sender_ = new rm_common::ShooterCommandSender(shooter_nh);
-  ros::NodeHandle camera_nh(nh, "camera");
-  camera_switch_cmd_sender_ = new rm_common::CameraSwitchCommandSender(camera_nh);
+  if (nh.hasParam("camera"))
+  {
+    ros::NodeHandle camera_nh(nh, "camera");
+    camera_switch_cmd_sender_ = new rm_common::CameraSwitchCommandSender(camera_nh);
+  }
 
   ros::NodeHandle detection_switch_nh(nh, "detection_switch");
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
@@ -128,7 +131,8 @@ void ChassisGimbalShooterManual::sendCommand(const ros::Time& time)
 {
   ChassisGimbalManual::sendCommand(time);
   shooter_cmd_sender_->sendCommand(time);
-  camera_switch_cmd_sender_->sendCommand(time);
+  if (camera_switch_cmd_sender_)
+    camera_switch_cmd_sender_->sendCommand(time);
 }
 
 void ChassisGimbalShooterManual::remoteControlTurnOff()
@@ -337,7 +341,8 @@ void ChassisGimbalShooterManual::bPress()
 
 void ChassisGimbalShooterManual::rPress()
 {
-  camera_switch_cmd_sender_->switchCamera();
+  if (camera_switch_cmd_sender_)
+    camera_switch_cmd_sender_->switchCamera();
 }
 
 void ChassisGimbalShooterManual::wPress()


### PR DESCRIPTION
问题：由于英雄有切换相机的需求，所以在chassis gimbal shooter manual中构造了一个camera switch command sender，但是步兵不需要这个功能，并不需要构造。按照现在的代码，如果配置文件中没有相关参数会导致报错
解决方法：判断配置文件中是否有“camera”，没有就不构造camera switch command sender