### PR TITLE
Added hero and standard self-aiming mode switching buttons

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -25,6 +25,8 @@ protected:
   void rightSwitchDownRise() override;
   void rightSwitchMidRise() override;
   void rightSwitchUpRise() override;
+  void rPress() override;
+  void ePress() override;
   void ctrlZPress();
   void ctrlZRelease()
   {

--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -33,6 +33,8 @@ protected:
     gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
   };
   void ctrlQPress();
+  rm_common::SwitchDetectionCaller* switch_buff_srv_{};
+  rm_common::SwitchDetectionCaller* switch_buff_type_srv_{};
   rm_common::JointPositionBinaryCommandSender* cover_command_sender_{};
   rm_common::CalibrationQueue* gimbal_calibration_;
   InputEvent ctrl_z_event_, ctrl_q_event_;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -105,6 +105,7 @@ protected:
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
+  rm_common::SwitchDetectionCaller* switch_armor_target_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 
   geometry_msgs::PointStamped point_out_;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -59,6 +59,7 @@ protected:
   void mouseRightRelease()
   {
     gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
+    shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
   }
   void wPress() override;
   void aPress() override;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -46,6 +46,7 @@ protected:
   void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data) override;
   void gameStatusCallback(const rm_msgs::GameStatus::ConstPtr& data) override;
   void gimbalDesErrorCallback(const rm_msgs::GimbalDesError::ConstPtr& data) override;
+  void suggestFireCallback(const std_msgs::BoolConstPtr& data) override;
   void trackCallback(const rm_msgs::TrackData::ConstPtr& data) override;
   void leftSwitchUpOn(ros::Duration duration);
   void mouseLeftPress();
@@ -102,6 +103,6 @@ protected:
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 
-  bool prepare_shoot_ = false;
+  bool prepare_shoot_ = false, suggest_fire_ = false;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -59,7 +59,8 @@ protected:
   void mouseRightRelease()
   {
     gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
-    shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
+    if (shooter_cmd_sender_->getMsg()->mode == rm_msgs::ShootCmd::PUSH)
+      shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
   }
   void wPress() override;
   void aPress() override;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -82,6 +82,7 @@ protected:
   void xPress();
   void xReleasing();
   void rPress();
+  void gPress();
   void qPress()
   {
     if (shooter_cmd_sender_->getShootFrequency() != rm_common::HeatLimit::LOW)

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -106,8 +106,6 @@ protected:
   rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::SwitchDetectionCaller* switch_armor_target_srv_{};
-  rm_common::SwitchDetectionCaller* switch_buff_srv_{};
-  rm_common::SwitchDetectionCaller* switch_buff_type_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 
   geometry_msgs::PointStamped point_out_;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -46,7 +46,7 @@ protected:
   void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data) override;
   void gameStatusCallback(const rm_msgs::GameStatus::ConstPtr& data) override;
   void gimbalDesErrorCallback(const rm_msgs::GimbalDesError::ConstPtr& data) override;
-  void suggestFireCallback(const std_msgs::BoolConstPtr& data) override;
+  void suggestFireCallback(const std_msgs::Bool::ConstPtr& data) override;
   void trackCallback(const rm_msgs::TrackData::ConstPtr& data) override;
   void leftSwitchUpOn(ros::Duration duration);
   void mouseLeftPress();
@@ -103,6 +103,6 @@ protected:
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
 
-  bool prepare_shoot_ = false, suggest_fire_ = false;
+  bool prepare_shoot_ = false;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -77,11 +77,11 @@ protected:
   void dRelease() override;
 
   virtual void ePress();
+  virtual void rPress();
   void cPress();
   void bPress();
   void xPress();
   void xReleasing();
-  void rPress();
   void gPress();
   void qPress()
   {
@@ -97,12 +97,11 @@ protected:
   void shiftPress();
   void shiftRelease();
   void ctrlVPress();
-  void ctrlRPress();
   void ctrlBPress();
 
   InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, r_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
-      ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
+      f_event_, b_event_, x_event_, r_event_, ctrl_v_event_, ctrl_b_event_, shift_event_, ctrl_shift_b_event_,
+      mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -76,7 +76,7 @@ protected:
   void sRelease() override;
   void dRelease() override;
 
-  void ePress();
+  virtual void ePress();
   void cPress();
   void bPress();
   void xPress();

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -92,13 +92,12 @@ protected:
   }
   void shiftPress();
   void shiftRelease();
-  void ctrlCPress();
   void ctrlVPress();
   void ctrlRPress();
   void ctrlBPress();
 
   InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
+      f_event_, b_event_, x_event_, r_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
       ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <ros/ros.h>
 #include <serial/serial.h>
+#include <std_msgs/Bool.h>
 #include <tf2_ros/buffer.h>
 #include <nav_msgs/Odometry.h>
 #include <tf/transform_listener.h>
@@ -75,6 +76,9 @@ protected:
   virtual void gameStatusCallback(const rm_msgs::GameStatus::ConstPtr& data)
   {
   }
+  virtual void suggestFireCallback(const std_msgs::BoolConstPtr& data)
+  {
+  }
 
   // Referee
   virtual void chassisOutputOn()
@@ -115,7 +119,8 @@ protected:
   ros::Publisher manual_to_referee_pub_;
 
   ros::Subscriber odom_sub_, dbus_sub_, track_sub_, referee_sub_, capacity_sub_, game_status_sub_, joint_state_sub_,
-      game_robot_hp_sub_, actuator_state_sub_, power_heat_data_sub_, gimbal_des_error_sub_, game_robot_status_sub_;
+      game_robot_hp_sub_, actuator_state_sub_, power_heat_data_sub_, gimbal_des_error_sub_, game_robot_status_sub_,
+      suggest_fire_sub_;
 
   sensor_msgs::JointState joint_state_;
   rm_msgs::TrackData track_data_;

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -76,7 +76,7 @@ protected:
   virtual void gameStatusCallback(const rm_msgs::GameStatus::ConstPtr& data)
   {
   }
-  virtual void suggestFireCallback(const std_msgs::BoolConstPtr& data)
+  virtual void suggestFireCallback(const std_msgs::Bool::ConstPtr& data)
   {
   }
 

--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -12,6 +12,10 @@ ChassisGimbalShooterCoverManual::ChassisGimbalShooterCoverManual(ros::NodeHandle
   ros::NodeHandle cover_nh(nh, "cover");
   nh.param("supply_frame", supply_frame_, std::string("supply_frame"));
   cover_command_sender_ = new rm_common::JointPositionBinaryCommandSender(cover_nh);
+  ros::NodeHandle buff_switch_nh(nh, "buff_switch");
+  switch_buff_srv_ = new rm_common::SwitchDetectionCaller(buff_switch_nh);
+  ros::NodeHandle buff_type_switch_nh(nh, "buff_type_switch");
+  switch_buff_type_srv_ = new rm_common::SwitchDetectionCaller(buff_type_switch_nh);
   XmlRpc::XmlRpcValue rpc_value;
   nh.getParam("gimbal_calibration", rpc_value);
   gimbal_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
@@ -36,6 +40,10 @@ void ChassisGimbalShooterCoverManual::updatePc(const rm_msgs::DbusData::ConstPtr
 void ChassisGimbalShooterCoverManual::checkReferee()
 {
   manual_to_referee_pub_data_.cover_state = cover_command_sender_->getState();
+  if (switch_detection_srv_->getTarget() != rm_msgs::StatusChangeRequest::ARMOR)
+    manual_to_referee_pub_data_.det_target = switch_buff_type_srv_->getTarget();
+  else
+    manual_to_referee_pub_data_.det_target = switch_detection_srv_->getTarget();
   ChassisGimbalShooterManual::checkReferee();
 }
 void ChassisGimbalShooterCoverManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data)

--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -133,6 +133,28 @@ void ChassisGimbalShooterCoverManual::rightSwitchUpRise()
   supply_ = false;
 }
 
+void ChassisGimbalShooterCoverManual::rPress()
+{
+  if (switch_buff_srv_->getTarget() != rm_msgs::StatusChangeRequest::ARMOR)
+  {
+    if (switch_buff_type_srv_->getTarget() == rm_msgs::StatusChangeRequest::SMALL_BUFF)
+      switch_buff_type_srv_->setTargetType(rm_msgs::StatusChangeRequest::BIG_BUFF);
+    else
+      switch_buff_type_srv_->setTargetType(rm_msgs::StatusChangeRequest::SMALL_BUFF);
+    switch_buff_type_srv_->callService();
+  }
+}
+
+void ChassisGimbalShooterCoverManual::ePress()
+{
+  switch_buff_srv_->switchTargetType();
+  switch_detection_srv_->switchTargetType();
+  switch_buff_type_srv_->setTargetType(switch_buff_srv_->getTarget());
+  switch_buff_srv_->callService();
+  switch_detection_srv_->callService();
+  switch_buff_type_srv_->callService();
+}
+
 void ChassisGimbalShooterCoverManual::ctrlZPress()
 {
   supply_ = !cover_command_sender_->getState();

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -309,15 +309,9 @@ void ChassisGimbalShooterManual::mouseRightPress()
 
 void ChassisGimbalShooterManual::ePress()
 {
-  if (chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::TWIST)
-  {
-    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-  }
-  else
-  {
-    chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::TWIST);
-    chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
-  }
+  switch_detection_srv_->switchArmorTargetType();
+  switch_detection_srv_->callService();
+  shooter_cmd_sender_->setArmorType(switch_detection_srv_->getArmorTarget());
 }
 
 void ChassisGimbalShooterManual::cPress()
@@ -453,13 +447,6 @@ void ChassisGimbalShooterManual::shiftPress()
 void ChassisGimbalShooterManual::shiftRelease()
 {
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
-}
-
-void ChassisGimbalShooterManual::ctrlCPress()
-{
-  switch_detection_srv_->switchArmorTargetType();
-  switch_detection_srv_->callService();
-  shooter_cmd_sender_->setArmorType(switch_detection_srv_->getArmorTarget());
 }
 
 void ChassisGimbalShooterManual::ctrlVPress()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -220,8 +220,6 @@ void ChassisGimbalShooterManual::rightSwitchDownRise()
   ChassisGimbalManual::rightSwitchDownRise();
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
   shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::STOP);
-  if (camera_switch_cmd_sender_)
-    camera_switch_cmd_sender_->switchCamera();
 }
 
 void ChassisGimbalShooterManual::rightSwitchMidRise()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -38,6 +38,7 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   x_event_.setRising(boost::bind(&ChassisGimbalShooterManual::xPress, this));
   x_event_.setActiveLow(boost::bind(&ChassisGimbalShooterManual::xReleasing, this));
   r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::rPress, this));
+  g_event_.setRising(boost::bind(&ChassisGimbalShooterManual::gPress, this));
   ctrl_v_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlVPress, this));
   ctrl_r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlRPress, this));
   ctrl_b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlBPress, this));
@@ -219,6 +220,8 @@ void ChassisGimbalShooterManual::rightSwitchDownRise()
   ChassisGimbalManual::rightSwitchDownRise();
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
   shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::STOP);
+  if (camera_switch_cmd_sender_)
+    camera_switch_cmd_sender_->switchCamera();
 }
 
 void ChassisGimbalShooterManual::rightSwitchMidRise()
@@ -351,6 +354,12 @@ void ChassisGimbalShooterManual::rPress()
 {
   if (camera_switch_cmd_sender_)
     camera_switch_cmd_sender_->switchCamera();
+}
+
+void ChassisGimbalShooterManual::gPress()
+{
+  switch_detection_srv_->switchTargetType();
+  switch_detection_srv_->callService();
 }
 
 void ChassisGimbalShooterManual::wPress()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -122,9 +122,10 @@ void ChassisGimbalShooterManual::trackCallback(const rm_msgs::TrackData::ConstPt
   shooter_cmd_sender_->updateTrackData(*data);
 }
 
-void ChassisGimbalShooterManual::suggestFireCallback(const std_msgs::BoolConstPtr& data)
+void ChassisGimbalShooterManual::suggestFireCallback(const std_msgs::Bool::ConstPtr& data)
 {
-  suggest_fire_ = data->data;
+  ManualBase::suggestFireCallback(data);
+  shooter_cmd_sender_->updateSuggestFireData(*data);
 }
 
 void ChassisGimbalShooterManual::sendCommand(const ros::Time& time)
@@ -295,10 +296,14 @@ void ChassisGimbalShooterManual::mouseRightPress()
   {
     gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::TRACK);
     gimbal_cmd_sender_->setBulletSpeed(shooter_cmd_sender_->getSpeed());
-    if (suggest_fire_ && shooter_cmd_sender_->getMsg()->mode == rm_msgs::ShootCmd::READY)
+  }
+  if (switch_detection_srv_->getArmorTarget() == rm_msgs::StatusChangeRequest::ARMOR_OUTPOST_BASE)
+  {
+    if (shooter_cmd_sender_->getMsg()->mode != rm_msgs::ShootCmd::STOP)
+    {
       shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::PUSH);
-    else
-      shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::READY);
+      shooter_cmd_sender_->checkError(ros::Time::now());
+    }
   }
 }
 

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -301,7 +301,7 @@ void ChassisGimbalShooterManual::mouseRightPress()
     gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::TRACK);
     gimbal_cmd_sender_->setBulletSpeed(shooter_cmd_sender_->getSpeed());
   }
-  if (switch_detection_srv_->getArmorTarget() == rm_msgs::StatusChangeRequest::ARMOR_OUTPOST_BASE)
+  if (switch_armor_target_srv_->getArmorTarget() == rm_msgs::StatusChangeRequest::ARMOR_OUTPOST_BASE)
   {
     if (shooter_cmd_sender_->getMsg()->mode != rm_msgs::ShootCmd::STOP)
     {

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -459,7 +459,7 @@ void ChassisGimbalShooterManual::ctrlCPress()
 {
   switch_detection_srv_->switchArmorTargetType();
   switch_detection_srv_->callService();
-  ROS_INFO_STREAM("target type: " << switch_detection_srv_->getArmorTarget());
+  shooter_cmd_sender_->setArmorType(switch_detection_srv_->getArmorTarget());
 }
 
 void ChassisGimbalShooterManual::ctrlVPress()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -31,7 +31,6 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   f_event_.setRising(boost::bind(&ChassisGimbalShooterManual::fPress, this));
   b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::bPress, this));
   r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::rPress, this));
-  ctrl_c_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlCPress, this));
   ctrl_v_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlVPress, this));
   ctrl_r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlRPress, this));
   ctrl_b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlBPress, this));
@@ -73,7 +72,6 @@ void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr
   b_event_.update((!dbus_data->key_ctrl && !dbus_data->key_shift) & dbus_data->key_b);
   x_event_.update(dbus_data->key_x);
   r_event_.update((!dbus_data->key_ctrl) & dbus_data->key_r);
-  ctrl_c_event_.update(dbus_data->key_ctrl & dbus_data->key_c);
   ctrl_v_event_.update(dbus_data->key_ctrl & dbus_data->key_v);
   ctrl_r_event_.update(dbus_data->key_ctrl & dbus_data->key_r);
   ctrl_b_event_.update(dbus_data->key_ctrl & dbus_data->key_b & !dbus_data->key_shift);

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -21,10 +21,6 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
   ros::NodeHandle armor_target_switch_nh(nh, "armor_target_switch");
   switch_armor_target_srv_ = new rm_common::SwitchDetectionCaller(armor_target_switch_nh);
-  ros::NodeHandle buff_switch_nh(nh, "buff_switch");
-  switch_buff_srv_ = new rm_common::SwitchDetectionCaller(buff_switch_nh);
-  ros::NodeHandle buff_type_switch_nh(nh, "buff_type_switch");
-  switch_buff_type_srv_ = new rm_common::SwitchDetectionCaller(buff_type_switch_nh);
   XmlRpc::XmlRpcValue rpc_value;
   nh.getParam("shooter_calibration", rpc_value);
   shooter_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
@@ -67,10 +63,6 @@ void ChassisGimbalShooterManual::checkReferee()
   manual_to_referee_pub_data_.det_armor_target = switch_detection_srv_->getArmorTarget();
   manual_to_referee_pub_data_.det_color = switch_detection_srv_->getColor();
   manual_to_referee_pub_data_.det_exposure = switch_detection_srv_->getExposureLevel();
-  if (switch_detection_srv_->getTarget() != rm_msgs::StatusChangeRequest::ARMOR)
-    manual_to_referee_pub_data_.det_target = switch_buff_type_srv_->getTarget();
-  else
-    manual_to_referee_pub_data_.det_target = switch_detection_srv_->getTarget();
   manual_to_referee_pub_data_.stamp = ros::Time::now();
   ChassisGimbalManual::checkReferee();
 }

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -16,6 +16,8 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
 
   ros::NodeHandle detection_switch_nh(nh, "detection_switch");
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
+  ros::NodeHandle armor_target_switch_nh(nh, "armor_target_switch");
+  switch_armor_target_srv_ = new rm_common::SwitchDetectionCaller(armor_target_switch_nh);
   XmlRpc::XmlRpcValue rpc_value;
   nh.getParam("shooter_calibration", rpc_value);
   shooter_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
@@ -311,9 +313,9 @@ void ChassisGimbalShooterManual::mouseRightPress()
 
 void ChassisGimbalShooterManual::ePress()
 {
-  switch_detection_srv_->switchArmorTargetType();
-  switch_detection_srv_->callService();
-  shooter_cmd_sender_->setArmorType(switch_detection_srv_->getArmorTarget());
+  switch_armor_target_srv_->switchArmorTargetType();
+  switch_armor_target_srv_->callService();
+  shooter_cmd_sender_->setArmorType(switch_armor_target_srv_->getArmorTarget());
 }
 
 void ChassisGimbalShooterManual::cPress()

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -28,7 +28,7 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
       nh_referee.subscribe<rm_msgs::CapacityData>("capacity_data", 10, &ManualBase::capacityDataCallback, this);
   power_heat_data_sub_ =
       nh_referee.subscribe<rm_msgs::PowerHeatData>("power_heat_data", 10, &ManualBase::powerHeatDataCallback, this);
-  suggest_fire_sub_ = nh.subscribe("/forecast/suggest_fire", 1, &ManualBase::suggestFireCallback, this);
+  suggest_fire_sub_ = nh.subscribe<std_msgs::Bool>("/forecast/suggest_fire", 10, &ManualBase::suggestFireCallback, this);
 
   // pub
   manual_to_referee_pub_ = nh.advertise<rm_msgs::ManualToReferee>("/manual_to_referee", 1);

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -28,6 +28,8 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
       nh_referee.subscribe<rm_msgs::CapacityData>("capacity_data", 10, &ManualBase::capacityDataCallback, this);
   power_heat_data_sub_ =
       nh_referee.subscribe<rm_msgs::PowerHeatData>("power_heat_data", 10, &ManualBase::powerHeatDataCallback, this);
+  suggest_fire_sub_ = nh.subscribe("/forecast/suggest_fire", 1, &ManualBase::suggestFireCallback, this);
+
   // pub
   manual_to_referee_pub_ = nh.advertise<rm_msgs::ManualToReferee>("/manual_to_referee", 1);
 

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -28,7 +28,8 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
       nh_referee.subscribe<rm_msgs::CapacityData>("capacity_data", 10, &ManualBase::capacityDataCallback, this);
   power_heat_data_sub_ =
       nh_referee.subscribe<rm_msgs::PowerHeatData>("power_heat_data", 10, &ManualBase::powerHeatDataCallback, this);
-  suggest_fire_sub_ = nh.subscribe<std_msgs::Bool>("/forecast/suggest_fire", 10, &ManualBase::suggestFireCallback, this);
+  suggest_fire_sub_ =
+      nh.subscribe<std_msgs::Bool>("/forecast/suggest_fire", 10, &ManualBase::suggestFireCallback, this);
 
   // pub
   manual_to_referee_pub_ = nh.advertise<rm_msgs::ManualToReferee>("/manual_to_referee", 1);


### PR DESCRIPTION
对代码进行了以下修改：
1. 增加一个话题订阅者以及回调，接收视觉发过来的数据判断是否发射，这个用于打旋转装甲板
2. 用e来切换自瞄击打旋转装甲板和打普通装甲板
3. 增加g用来识别紫色装甲板