### PR TITLE
Update for new power management

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -85,7 +85,6 @@ protected:
   virtual void xReleasing();
   virtual void shiftPress();
   virtual void shiftRelease();
-  void bRelease();
   void qPress()
   {
     if (shooter_cmd_sender_->getShootFrequency() != rm_common::HeatLimit::LOW)

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -80,6 +80,7 @@ protected:
   virtual void rPress();
   void cPress();
   void bPress();
+  void bRelease();
   void xPress();
   void xReleasing();
   void gPress();

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -124,6 +124,7 @@ protected:
       suggest_fire_sub_;
 
   sensor_msgs::JointState joint_state_;
+  rm_msgs::CapacityData capacity_data_;
   rm_msgs::TrackData track_data_;
   rm_msgs::ManualToReferee manual_to_referee_pub_data_;
 
@@ -135,9 +136,9 @@ protected:
   ros::NodeHandle nh_;
 
   ros::Time referee_last_get_stamp_;
-  bool remote_is_open_{}, referee_is_online_ = false;
+  bool remote_is_open_{}, referee_is_online_ = false, capacity_is_online_ = false;
   int state_ = PASSIVE;
-  int robot_id_, chassis_power_;
+  int robot_id_;
   InputEvent robot_hp_event_, right_switch_down_event_, right_switch_mid_event_, right_switch_up_event_,
       left_switch_down_event_, left_switch_mid_event_, left_switch_up_event_;
 };

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -34,6 +34,7 @@
 #include <rm_msgs/GimbalDesError.h>
 #include <rm_msgs/GameRobotStatus.h>
 #include <rm_msgs/ManualToReferee.h>
+#include <rm_msgs/PowerManagementSampleAndStatusData.h>
 #include "rm_manual/input_event.h"
 
 namespace rm_manual
@@ -65,7 +66,9 @@ protected:
   virtual void trackCallback(const rm_msgs::TrackData::ConstPtr& data);
   virtual void gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data);
   virtual void powerHeatDataCallback(const rm_msgs::PowerHeatData::ConstPtr& data);
-  virtual void capacityDataCallback(const rm_msgs::PowerManagementSampleAndStatusData ::ConstPtr& data);
+  virtual void capacityDataCallback(const rm_msgs::PowerManagementSampleAndStatusData::ConstPtr& data)
+  {
+  }
   virtual void gimbalDesErrorCallback(const rm_msgs::GimbalDesError::ConstPtr& data)
   {
   }
@@ -126,7 +129,6 @@ protected:
       suggest_fire_sub_;
 
   sensor_msgs::JointState joint_state_;
-  rm_msgs::CapacityData capacity_data_;
   rm_msgs::TrackData track_data_;
   rm_msgs::ManualToReferee manual_to_referee_pub_data_;
 
@@ -138,7 +140,7 @@ protected:
   ros::NodeHandle nh_;
 
   ros::Time referee_last_get_stamp_;
-  bool remote_is_open_{}, referee_is_online_ = false, capacity_is_online_ = false;
+  bool remote_is_open_{}, referee_is_online_ = false;
   int state_ = PASSIVE;
   int robot_id_, chassis_power_;
   InputEvent robot_hp_event_, right_switch_down_event_, right_switch_mid_event_, right_switch_up_event_,

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -34,7 +34,8 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   c_event_.setRising(boost::bind(&ChassisGimbalShooterManual::cPress, this));
   q_event_.setRising(boost::bind(&ChassisGimbalShooterManual::qPress, this));
   f_event_.setRising(boost::bind(&ChassisGimbalShooterManual::fPress, this));
-  b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::bPress, this));
+  b_event_.setEdge(boost::bind(&ChassisGimbalShooterManual::bPress, this),
+                   boost::bind(&ChassisGimbalShooterManual::bRelease, this));
   x_event_.setRising(boost::bind(&ChassisGimbalShooterManual::xPress, this));
   x_event_.setActiveLow(boost::bind(&ChassisGimbalShooterManual::xReleasing, this));
   r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::rPress, this));
@@ -334,6 +335,11 @@ void ChassisGimbalShooterManual::cPress()
 void ChassisGimbalShooterManual::bPress()
 {
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
+}
+
+void ChassisGimbalShooterManual::bRelease()
+{
+  chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
 }
 
 void ChassisGimbalShooterManual::rPress()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -34,8 +34,7 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   c_event_.setRising(boost::bind(&ChassisGimbalShooterManual::cPress, this));
   q_event_.setRising(boost::bind(&ChassisGimbalShooterManual::qPress, this));
   f_event_.setRising(boost::bind(&ChassisGimbalShooterManual::fPress, this));
-  b_event_.setEdge(boost::bind(&ChassisGimbalShooterManual::bPress, this),
-                   boost::bind(&ChassisGimbalShooterManual::bRelease, this));
+  b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::bPress, this));
   x_event_.setRising(boost::bind(&ChassisGimbalShooterManual::xPress, this));
   x_event_.setActiveLow(boost::bind(&ChassisGimbalShooterManual::xReleasing, this));
   r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::rPress, this));

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -201,15 +201,6 @@ void ChassisGimbalShooterManual::updateRc(const rm_msgs::DbusData::ConstPtr& dbu
 void ChassisGimbalShooterManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
 {
   ChassisGimbalManual::updatePc(dbus_data);
-  if (chassis_cmd_sender_->power_limit_->getState() != rm_common::PowerLimit::CHARGE && !is_gyro_)
-  {
-    if (!dbus_data->key_shift && chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::FOLLOW &&
-        std::sqrt(std::pow(vel_cmd_sender_->getMsg()->linear.x, 2) + std::pow(vel_cmd_sender_->getMsg()->linear.y, 2)) >
-            0.0)
-      chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
-    else if (chassis_power_ < 1.0 && chassis_cmd_sender_->getMsg()->mode == rm_msgs::ChassisCmd::FOLLOW)
-      chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::BURST);
-  }
 }
 
 void ChassisGimbalShooterManual::rightSwitchDownRise()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "rm_manual/chassis_gimbal_shooter_cover_manual.h"
 #include "rm_manual/engineer_manual.h"
 #include "rm_manual/dart_manual.h"
+#include "rm_manual/balance_manual.h"
 
 int main(int argc, char** argv)
 {
@@ -23,6 +24,8 @@ int main(int argc, char** argv)
     manual_control = new rm_manual::EngineerManual(nh, nh_referee);
   else if (robot == "dart")
     manual_control = new rm_manual::DartManual(nh, nh_referee);
+  else if (robot == "balance")
+    manual_control = new rm_manual::BalanceManual(nh, nh_referee);
   else
   {
     ROS_ERROR("no robot type ");

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -49,6 +49,7 @@ void ManualBase::run()
 {
   checkReferee();
   controller_manager_.update();
+  capacity_is_online_ = ros::Time::now() - capacity_data_.stamp < ros::Duration(0.3);
 }
 
 void ManualBase::checkReferee()
@@ -112,7 +113,7 @@ void ManualBase::powerHeatDataCallback(const rm_msgs::PowerHeatData::ConstPtr& d
 
 void ManualBase::capacityDataCallback(const rm_msgs::CapacityData::ConstPtr& data)
 {
-  chassis_power_ = data->chassis_power;
+  capacity_data_ = *data;
 }
 
 void ManualBase::updateRc(const rm_msgs::DbusData::ConstPtr& dbus_data)

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -24,8 +24,8 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
       nh_referee.subscribe<rm_msgs::GameRobotHp>("game_robot_hp", 10, &ManualBase::gameRobotHpCallback, this);
   game_status_sub_ =
       nh_referee.subscribe<rm_msgs::GameStatus>("game_status", 10, &ManualBase::gameStatusCallback, this);
-  capacity_sub_ =
-      nh_referee.subscribe<rm_msgs::PowerManagementSampleAndStatusData>("power_management/sample_and_status", 10, &ManualBase::capacityDataCallback, this);
+  capacity_sub_ = nh_referee.subscribe<rm_msgs::PowerManagementSampleAndStatusData>(
+      "power_management/sample_and_status", 10, &ManualBase::capacityDataCallback, this);
   power_heat_data_sub_ =
       nh_referee.subscribe<rm_msgs::PowerHeatData>("power_heat_data", 10, &ManualBase::powerHeatDataCallback, this);
   suggest_fire_sub_ =
@@ -66,7 +66,6 @@ void ManualBase::run()
 {
   checkReferee();
   controller_manager_.update();
-  capacity_is_online_ = ros::Time::now() - capacity_data_.stamp < ros::Duration(0.3);
 }
 
 void ManualBase::checkReferee()
@@ -152,11 +151,6 @@ void ManualBase::gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPt
 void ManualBase::powerHeatDataCallback(const rm_msgs::PowerHeatData::ConstPtr& data)
 {
   referee_last_get_stamp_ = data->stamp;
-}
-
-void ManualBase::capacityDataCallback(const rm_msgs::PowerManagementSampleAndStatusData ::ConstPtr& data)
-{
-  capacity_data_ = *data;
 }
 
 void ManualBase::updateRc(const rm_msgs::DbusData::ConstPtr& dbus_data)


### PR DESCRIPTION
根据新的超电硬件和固件修改了manual中超电部分的逻辑。
改动有原先的点按b切换充电的功能改为长按触发，修改了自动充电的处罚条件，替换capacity msg名字等

本pr在开发中由于测试需要，是基于另一个[pr](https://github.com/rm-controls/rm_manual/pull/53)进行修改