### PR TITLE
Add function for shooter calibration of key ctrl q

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -30,7 +30,7 @@ protected:
   {
     gimbal_cmd_sender_->setMode(rm_msgs::GimbalCmd::RATE);
   };
-  void ctrlQPress();
+  void ctrlQPress() override;
   rm_common::JointPositionBinaryCommandSender* cover_command_sender_{};
   rm_common::CalibrationQueue* gimbal_calibration_;
   InputEvent ctrl_z_event_, ctrl_q_event_;

--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -33,7 +33,7 @@ protected:
   void ctrlQPress() override;
   rm_common::JointPositionBinaryCommandSender* cover_command_sender_{};
   rm_common::CalibrationQueue* gimbal_calibration_;
-  InputEvent ctrl_z_event_, ctrl_q_event_;
+  InputEvent ctrl_z_event_;
   std::string supply_frame_;
   bool supply_ = false;
   bool cover_close_ = true;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -99,8 +99,8 @@ protected:
   virtual void ctrlQPress();
 
   InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,
-      ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
+      f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, ctrl_q_event_,
+      shift_event_, ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -96,6 +96,7 @@ protected:
   void ctrlVPress();
   void ctrlRPress();
   void ctrlBPress();
+  virtual void ctrlQPress();
 
   InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
       f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, shift_event_,

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -101,8 +101,8 @@ protected:
   virtual void ctrlQPress();
 
   InputEvent shooter_power_on_event_, self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_,
-      f_event_, b_event_, x_event_, r_event_, ctrl_c_event_, ctrl_v_event_, ctrl_r_event_, ctrl_b_event_, ctrl_q_event_,
-      shift_event_, ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;;
+      f_event_, b_event_, x_event_, r_event_, ctrl_v_event_, ctrl_b_event_, ctrl_q_event_, shift_event_,
+      ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};

--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -139,6 +139,7 @@ void ChassisGimbalShooterCoverManual::ctrlZPress()
 
 void ChassisGimbalShooterCoverManual::ctrlQPress()
 {
+  ChassisGimbalShooterManual::ctrlQPress();
   gimbal_calibration_->reset();
 }
 }  // namespace rm_manual

--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -49,7 +49,6 @@ void ChassisGimbalShooterCoverManual::checkKeyboard(const rm_msgs::DbusData::Con
 {
   ChassisGimbalShooterManual::checkKeyboard(dbus_data);
   ctrl_z_event_.update(dbus_data->key_ctrl & dbus_data->key_z);
-  ctrl_q_event_.update(dbus_data->key_ctrl & dbus_data->key_q);
 }
 
 void ChassisGimbalShooterCoverManual::sendCommand(const ros::Time& time)

--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -17,7 +17,6 @@ ChassisGimbalShooterCoverManual::ChassisGimbalShooterCoverManual(ros::NodeHandle
   gimbal_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
   ctrl_z_event_.setEdge(boost::bind(&ChassisGimbalShooterCoverManual::ctrlZPress, this),
                         boost::bind(&ChassisGimbalShooterCoverManual::ctrlZRelease, this));
-  ctrl_q_event_.setRising(boost::bind(&ChassisGimbalShooterCoverManual::ctrlQPress, this));
 }
 
 void ChassisGimbalShooterCoverManual::run()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -40,6 +40,7 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   ctrl_v_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlVPress, this));
   ctrl_r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlRPress, this));
   ctrl_b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlBPress, this));
+  ctrl_q_event_.setRising(boost::bind(&ChassisGimbalShooterManual::ctrlQPress, this));
   shift_event_.setEdge(boost::bind(&ChassisGimbalShooterManual::shiftPress, this),
                        boost::bind(&ChassisGimbalShooterManual::shiftRelease, this));
   mouse_left_event_.setActiveHigh(boost::bind(&ChassisGimbalShooterManual::mouseLeftPress, this));

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -534,4 +534,8 @@ void ChassisGimbalShooterManual::ctrlBPress()
   switch_detection_srv_->callService();
 }
 
+void ChassisGimbalShooterManual::ctrlQPress()
+{
+  shooter_calibration_->reset();
+}
 }  // namespace rm_manual

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -81,6 +81,7 @@ void ChassisGimbalShooterManual::checkKeyboard(const rm_msgs::DbusData::ConstPtr
   r_event_.update((!dbus_data->key_ctrl) & dbus_data->key_r);
   ctrl_v_event_.update(dbus_data->key_ctrl & dbus_data->key_v);
   ctrl_b_event_.update(dbus_data->key_ctrl & dbus_data->key_b & !dbus_data->key_shift);
+  ctrl_q_event_.update(dbus_data->key_ctrl & dbus_data->key_q);
   shift_event_.update(dbus_data->key_shift & !dbus_data->key_ctrl);
   ctrl_shift_b_event_.update(dbus_data->key_ctrl & dbus_data->key_shift & dbus_data->key_b);
   mouse_left_event_.update(dbus_data->p_l);


### PR DESCRIPTION
在chassis_gimbal_shooter_manual中使用ctrl q用来校准拨盘，同时在chassis_gimbal_shooter_cover_manual中重写ctrlQPress函数，校准拨盘、云台、弹仓。