### PR TITLE
Set the state when the right switch is high

### DIFF
--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -109,6 +109,18 @@ protected:
   virtual void leftSwitchMidRise(){};
   virtual void leftSwitchMidFall(){};
   virtual void leftSwitchUpRise(){};
+  virtual void rightSwitchDownOn()
+  {
+    state_ = IDLE;
+  };
+  virtual void rightSwitchMidOn()
+  {
+    state_ = RC;
+  };
+  virtual void rightSwitchUpOn()
+  {
+    state_ = PC;
+  };
   virtual void rightSwitchDownRise()
   {
     state_ = IDLE;

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -111,19 +111,11 @@ protected:
   virtual void leftSwitchMidOn(){};
   virtual void leftSwitchUpRise(){};
   virtual void leftSwitchUpOn(){};
-  virtual void rightSwitchDownOn()
+  virtual void rightSwitchDownRise()
   {
     state_ = IDLE;
-  };
-  virtual void rightSwitchMidOn()
-  {
-    state_ = RC;
-  };
-  virtual void rightSwitchUpOn()
-  {
-    state_ = PC;
-  };
-  virtual void rightSwitchDownRise()
+  }
+  virtual void rightSwitchDownOn()
   {
     state_ = IDLE;
   }
@@ -131,7 +123,15 @@ protected:
   {
     state_ = RC;
   }
+  virtual void rightSwitchMidOn()
+  {
+    state_ = RC;
+  }
   virtual void rightSwitchUpRise()
+  {
+    state_ = PC;
+  }
+  virtual void rightSwitchUpOn()
   {
     state_ = PC;
   }

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -38,6 +38,9 @@ ManualBase::ManualBase(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   right_switch_down_event_.setRising(boost::bind(&ManualBase::rightSwitchDownRise, this));
   right_switch_mid_event_.setRising(boost::bind(&ManualBase::rightSwitchMidRise, this));
   right_switch_up_event_.setRising(boost::bind(&ManualBase::rightSwitchUpRise, this));
+  right_switch_down_event_.setActiveHigh(boost::bind(&ManualBase::rightSwitchDownOn, this));
+  right_switch_mid_event_.setActiveHigh(boost::bind(&ManualBase::rightSwitchMidOn, this));
+  right_switch_up_event_.setActiveHigh(boost::bind(&ManualBase::rightSwitchUpOn, this));
   left_switch_down_event_.setRising(boost::bind(&ManualBase::leftSwitchDownRise, this));
   left_switch_up_event_.setRising(boost::bind(&ManualBase::leftSwitchUpRise, this));
   left_switch_mid_event_.setEdge(boost::bind(&ManualBase::leftSwitchMidRise, this),


### PR DESCRIPTION
1. 由于dbus的时间戳有时会有超过0.1s的时间没有更新，而此时遥控是开着的，会导致程序上认为遥控关闭，调用remoteControlTurnOff函数将state设为IDLE，当过了这一小段时间后，时间戳继续更新，会调用remoteControlTurnOn函数。但是由于state是上升沿触发，而上述过程中不会触发上升沿，因此state将一直保持IDLE，需要拨一下右拨杆触发上升沿切换state。
2. 解决方法：在高电平时设置state