### PR TITLE
Modify the logic of switching to purple target

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -111,6 +111,8 @@ protected:
 
   geometry_msgs::PointStamped point_out_;
 
+  uint8_t last_det_color_{};
+
   bool prepare_shoot_ = false, turn_flag_ = false, is_balance_ = false;
   double yaw_current_{};
 };

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -61,7 +61,7 @@ void ChassisGimbalShooterManual::checkReferee()
   manual_to_referee_pub_data_.power_limit_state = chassis_cmd_sender_->power_limit_->getState();
   manual_to_referee_pub_data_.shoot_frequency = shooter_cmd_sender_->getShootFrequency();
   manual_to_referee_pub_data_.gimbal_eject = gimbal_cmd_sender_->getEject();
-  manual_to_referee_pub_data_.det_armor_target = switch_detection_srv_->getArmorTarget();
+  manual_to_referee_pub_data_.det_armor_target = switch_armor_target_srv_->getArmorTarget();
   manual_to_referee_pub_data_.det_color = switch_detection_srv_->getColor();
   manual_to_referee_pub_data_.det_exposure = switch_detection_srv_->getExposureLevel();
   manual_to_referee_pub_data_.stamp = ros::Time::now();
@@ -355,7 +355,13 @@ void ChassisGimbalShooterManual::rPress()
 
 void ChassisGimbalShooterManual::gPress()
 {
-  switch_detection_srv_->setArmorTargetType(rm_msgs::StatusChangeRequest::ARMOR_OUTPOST_BASE);
+  if (switch_detection_srv_->getColor() != rm_msgs::StatusChangeRequest::PURPLE)
+  {
+    last_det_color_ = switch_detection_srv_->getColor();
+    switch_detection_srv_->setColor(rm_msgs::StatusChangeRequest::PURPLE);
+  }
+  else
+    switch_detection_srv_->setColor(last_det_color_);
   switch_detection_srv_->callService();
 }
 


### PR DESCRIPTION
1. 修改了切换紫色目标的按键函数的逻辑
2. 将manual_to_referee_pub_data_的det_armor_target修改为从switch_armor_target_srv_获取