### PR TITLE
Fixed capacity mode change bug

### DIFF
--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -60,7 +60,6 @@ void ChassisGimbalShooterCoverManual::sendCommand(const ros::Time& time)
   {
     chassis_cmd_sender_->getMsg()->follow_source_frame = supply_frame_;
     chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-    chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
     cover_close_ = false;
     try
     {
@@ -88,7 +87,6 @@ void ChassisGimbalShooterCoverManual::sendCommand(const ros::Time& time)
         {
           chassis_cmd_sender_->getMsg()->follow_source_frame = supply_frame_;
           chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::FOLLOW);
-          chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
         }
         else
         {


### PR DESCRIPTION
修复超电模式切换中出现的问题。
超点进入NORMAL无法切换其他状态的原因在cover的判断中，会强制设置模式为NORMAL。首先切换模式在开关弹仓的按键和拨杆中已经写好了，状态机里的是多余的;其次也正是这个的原因超电无法设置其他的状态