### PR TITLE
Fixed unreasonable overload error and optimized  the auto mode

### DIFF
--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -32,9 +32,6 @@ public:
   {
     NONE,
     AIMED
-    //    FIRST_OUTPOST,
-    //    SECOND_OUTPOST,
-    //    ALL_BASE
   };
 
 protected:
@@ -68,19 +65,17 @@ protected:
   double pitch_outpost_{}, pitch_base_{}, yaw_outpost_{}, yaw_base_{};
   double pitch_position_outpost_{}, yaw_position_outpost_{}, pitch_position_base_{}, yaw_position_base_{};
   double qd_, upward_vel_;
-  std::vector<double> qd_outpost_, qd_base_, yaw_offset_, yaw_offset_base_;
+  std::vector<double> qd_outpost_, qd_base_, yaw_offset_, yaw_offset_base_, launch_position_;
+  std::vector<double> aim_vector_;
   double scale_{ 0.04 }, scale_micro_{ 0.01 };
   bool if_stop_{ true };
 
-  //  bool launch_rest_flag_ = 0, has_launched_ = 0;
   rm_msgs::DbusData dbus_data_;
   rm_msgs::DartClientCmd dart_client_cmd_;
   rm_msgs::GameRobotStatus game_robot_status_;
   rm_msgs::GameStatus game_status_;
 
   int dart_fired_num_ = 0, initial_dart_fired_num_ = 0;
-  double launch_position_1_ = 0.003251, launch_position_2_ = 0.008298, launch_position_3_ = 0.014457,
-         launch_position_4_ = 0.018;
   double trigger_position_ = 0., pitch_velocity_ = 0., yaw_velocity_ = 0.;
   InputEvent wheel_clockwise_event_, wheel_anticlockwise_event_;
 
@@ -89,6 +84,5 @@ protected:
   int outpost_hp_;
   int dart_door_open_times_ = 0, last_dart_door_status_ = 1;
   int auto_state_ = OUTPOST, manual_state_ = OUTPOST, move_state_ = NORMAL, launch_state_ = NONE;
-  //      last_launch_state_ = FIRST_OUTPOST;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -49,6 +49,7 @@ protected:
   void updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data) override;
   void move(rm_common::JointPointCommandSender* joint, double ch);
   void recordPosition(const rm_msgs::DbusData dbus_data);
+  void waitAfterLaunch(const double time);
   void launchTwoDart();
   void getDartFiredNum();
   void triggerComeBackProtect();
@@ -66,9 +67,8 @@ protected:
   double pitch_position_outpost_{}, yaw_position_outpost_{}, pitch_position_base_{}, yaw_position_base_{};
   double qd_, upward_vel_;
   std::vector<double> qd_outpost_, qd_base_, yaw_offset_, yaw_offset_base_, launch_position_;
-  std::vector<double> aim_vector_;
   double scale_{ 0.04 }, scale_micro_{ 0.01 };
-  bool if_stop_{ true };
+  bool if_stop_{ true }, has_stopped{ false };
 
   rm_msgs::DbusData dbus_data_;
   rm_msgs::DartClientCmd dart_client_cmd_;
@@ -78,7 +78,7 @@ protected:
   int dart_fired_num_ = 0, initial_dart_fired_num_ = 0;
   double trigger_position_ = 0., pitch_velocity_ = 0., yaw_velocity_ = 0.;
   InputEvent wheel_clockwise_event_, wheel_anticlockwise_event_;
-
+  ros::Time stop_time_;
   ros::Subscriber dart_client_cmd_sub_;
   InputEvent dart_client_cmd_event_;
   int outpost_hp_;

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -9,6 +9,7 @@
 #include <rm_msgs/DartClientCmd.h>
 #include <rm_msgs/GameRobotStatus.h>
 #include <rm_msgs/GameStatus.h>
+#include <unordered_map>
 
 namespace rm_manual
 {
@@ -33,16 +34,23 @@ public:
     NONE,
     AIMED
   };
+  struct Dart
+  {
+    double outpost_offset_, base_offset_;
+    double outpost_qd_, base_qd_;
+    double trigger_position_;
+  };
 
 protected:
   void sendCommand(const ros::Time& time) override;
+  void getList(const XmlRpc::XmlRpcValue& darts, const XmlRpc::XmlRpcValue& targets);
   void run() override;
   void checkReferee() override;
   void remoteControlTurnOn() override;
   void leftSwitchMidOn();
   void leftSwitchDownOn();
   void leftSwitchUpOn();
-  void rightSwitchDownOn();
+  void rightSwitchDownOn() override;
   void rightSwitchMidRise() override;
   void rightSwitchUpRise() override;
   void updateRc(const rm_msgs::DbusData::ConstPtr& dbus_data) override;
@@ -64,9 +72,9 @@ protected:
   rm_common::JointPointCommandSender *pitch_sender_, *yaw_sender_;
   rm_common::CalibrationQueue *trigger_calibration_, *gimbal_calibration_;
   double pitch_outpost_{}, pitch_base_{}, yaw_outpost_{}, yaw_base_{};
-  double pitch_position_outpost_{}, yaw_position_outpost_{}, pitch_position_base_{}, yaw_position_base_{};
   double qd_, upward_vel_;
-  std::vector<double> qd_outpost_, qd_base_, yaw_offset_, yaw_offset_base_, launch_position_;
+  std::unordered_map<int, Dart> dart_list_{};
+  std::unordered_map<std::string, std::vector<double>> target_position_{};
   double scale_{ 0.04 }, scale_micro_{ 0.01 };
   bool if_stop_{ true }, has_stopped{ false };
 

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -31,9 +31,10 @@ public:
   enum LaunchMode
   {
     NONE,
-    FIRST_OUTPOST,
-    SECOND_OUTPOST,
-    ALL_BASE
+    AIMED
+    //    FIRST_OUTPOST,
+    //    SECOND_OUTPOST,
+    //    ALL_BASE
   };
 
 protected:
@@ -71,14 +72,15 @@ protected:
   double scale_{ 0.04 }, scale_micro_{ 0.01 };
   bool if_stop_{ true };
 
-  bool launch_rest_flag_ = 0, has_launched_ = 0;
+  //  bool launch_rest_flag_ = 0, has_launched_ = 0;
   rm_msgs::DbusData dbus_data_;
   rm_msgs::DartClientCmd dart_client_cmd_;
   rm_msgs::GameRobotStatus game_robot_status_;
   rm_msgs::GameStatus game_status_;
 
-  int dart_fired_num_ = 0;
-  double launch_position_1_ = 0.003251, launch_position_2_ = 0.008298, launch_position_3_ = 0.014457;
+  int dart_fired_num_ = 0, initial_dart_fired_num_ = 0;
+  double launch_position_1_ = 0.003251, launch_position_2_ = 0.008298, launch_position_3_ = 0.014457,
+         launch_position_4_ = 0.018;
   double trigger_position_ = 0., pitch_velocity_ = 0., yaw_velocity_ = 0.;
   InputEvent wheel_clockwise_event_, wheel_anticlockwise_event_;
 
@@ -86,7 +88,7 @@ protected:
   InputEvent dart_client_cmd_event_;
   int outpost_hp_;
   int dart_door_open_times_ = 0, last_dart_door_status_ = 1;
-  int auto_state_ = OUTPOST, manual_state_ = OUTPOST, move_state_ = NORMAL, launch_state_ = FIRST_OUTPOST,
-      last_launch_state_ = FIRST_OUTPOST;
+  int auto_state_ = OUTPOST, manual_state_ = OUTPOST, move_state_ = NORMAL, launch_state_ = NONE;
+  //      last_launch_state_ = FIRST_OUTPOST;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -71,9 +71,7 @@ protected:
   bool if_stop_{ true }, has_stopped{ false };
 
   rm_msgs::DbusData dbus_data_;
-  rm_msgs::DartClientCmd dart_client_cmd_;
-  rm_msgs::GameRobotStatus game_robot_status_;
-  rm_msgs::GameStatus game_status_;
+  uint8_t robot_id_, game_progress_, dart_launch_opening_status_;
 
   int dart_fired_num_ = 0, initial_dart_fired_num_ = 0;
   double trigger_position_ = 0., pitch_velocity_ = 0., yaw_velocity_ = 0.;

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -43,7 +43,8 @@ public:
 
 protected:
   void sendCommand(const ros::Time& time) override;
-  void getList(const XmlRpc::XmlRpcValue& darts, const XmlRpc::XmlRpcValue& targets);
+  void getList(const XmlRpc::XmlRpcValue& darts, const XmlRpc::XmlRpcValue& targets,
+               const XmlRpc::XmlRpcValue& launch_id, const XmlRpc::XmlRpcValue& trigger_position);
   void run() override;
   void checkReferee() override;
   void remoteControlTurnOn() override;

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -32,9 +32,9 @@ protected:
   void run() override;
   void checkReferee() override;
   void remoteControlTurnOn() override;
-  void leftSwitchMidOn() override;
-  void leftSwitchDownOn() override;
-  void leftSwitchUpOn() override;
+  void leftSwitchMidOn();
+  void leftSwitchDownOn();
+  void leftSwitchUpOn();
   void rightSwitchDownOn();
   void rightSwitchMidRise() override;
   void rightSwitchUpRise() override;

--- a/include/rm_manual/dart_manual.h
+++ b/include/rm_manual/dart_manual.h
@@ -24,7 +24,16 @@ public:
   enum MoveMode
   {
     NORMAL,
-    MICRO
+    MICRO,
+    MOVING,
+    STOP
+  };
+  enum LaunchMode
+  {
+    NONE,
+    FIRST_OUTPOST,
+    SECOND_OUTPOST,
+    ALL_BASE
   };
 
 protected:
@@ -62,7 +71,7 @@ protected:
   double scale_{ 0.04 }, scale_micro_{ 0.01 };
   bool if_stop_{ true };
 
-  bool launch_rest_flag_ = 0;
+  bool launch_rest_flag_ = 0, has_launched_ = 0;
   rm_msgs::DbusData dbus_data_;
   rm_msgs::DartClientCmd dart_client_cmd_;
   rm_msgs::GameRobotStatus game_robot_status_;
@@ -70,13 +79,14 @@ protected:
 
   int dart_fired_num_ = 0;
   double launch_position_1_ = 0.003251, launch_position_2_ = 0.008298, launch_position_3_ = 0.014457;
-  double trigger_position_ = 0.;
+  double trigger_position_ = 0., pitch_velocity_ = 0., yaw_velocity_ = 0.;
   InputEvent wheel_clockwise_event_, wheel_anticlockwise_event_;
 
   ros::Subscriber dart_client_cmd_sub_;
   InputEvent dart_client_cmd_event_;
   int outpost_hp_;
   int dart_door_open_times_ = 0, last_dart_door_status_ = 1;
-  int auto_state_ = OUTPOST, manual_state_ = OUTPOST, move_state_ = NORMAL;
+  int auto_state_ = OUTPOST, manual_state_ = OUTPOST, move_state_ = NORMAL, launch_state_ = FIRST_OUTPOST,
+      last_launch_state_ = FIRST_OUTPOST;
 };
 }  // namespace rm_manual

--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -106,12 +106,9 @@ protected:
   virtual void remoteControlTurnOff();
   virtual void remoteControlTurnOn();
   virtual void leftSwitchDownRise(){};
-  virtual void leftSwitchDownOn(){};
   virtual void leftSwitchMidRise(){};
   virtual void leftSwitchMidFall(){};
-  virtual void leftSwitchMidOn(){};
   virtual void leftSwitchUpRise(){};
-  virtual void leftSwitchUpOn(){};
   virtual void rightSwitchDownRise()
   {
     state_ = IDLE;

--- a/src/dart_manual.cpp
+++ b/src/dart_manual.cpp
@@ -190,7 +190,6 @@ void DartManual::remoteControlTurnOn()
 
 void DartManual::leftSwitchDownOn()
 {
-  ManualBase::leftSwitchDownOn();
   friction_right_sender_->setPoint(0.);
   friction_left_sender_->setPoint(0.);
   trigger_sender_->setPoint(-upward_vel_);
@@ -199,7 +198,6 @@ void DartManual::leftSwitchDownOn()
 
 void DartManual::leftSwitchMidOn()
 {
-  ManualBase::leftSwitchMidOn();
   dart_fired_num_ = 0;
   friction_right_sender_->setPoint(qd_);
   friction_left_sender_->setPoint(qd_);
@@ -209,7 +207,6 @@ void DartManual::leftSwitchMidOn()
 
 void DartManual::leftSwitchUpOn()
 {
-  ManualBase::leftSwitchUpOn();
   getDartFiredNum();
   launchTwoDart();
   switch (manual_state_)

--- a/src/dart_manual.cpp
+++ b/src/dart_manual.cpp
@@ -54,15 +54,16 @@ void DartManual::getList(const XmlRpc::XmlRpcValue& darts, const XmlRpc::XmlRpcV
 {
   for (const auto& dart : darts)
   {
-    ROS_ASSERT(dart.second.hasMember("param"));
-    ROS_ASSERT(dart.second["param"].getType() == XmlRpc::XmlRpcValue::TypeArray);
+    ROS_ASSERT(dart.second.hasMember("param") and dart.second.hasMember("id"));
+    ROS_ASSERT(dart.second["param"].getType() == XmlRpc::XmlRpcValue::TypeArray and
+               dart.second["id"].getType() == XmlRpc::XmlRpcValue::TypeInt);
     Dart dart_info;
     dart_info.outpost_offset_ = static_cast<double>(dart.second["param"][0]);
     dart_info.outpost_qd_ = static_cast<double>(dart.second["param"][1]);
     dart_info.base_offset_ = static_cast<double>(dart.second["param"][2]);
     dart_info.base_qd_ = static_cast<double>(dart.second["param"][3]);
     dart_info.trigger_position_ = static_cast<double>(dart.second["param"][4]);
-    dart_list_.insert(std::make_pair(std::stoi(dart.first) - 1, dart_info));
+    dart_list_.insert(std::make_pair(static_cast<int>(dart.second["id"]) - 1, dart_info));
   }
   for (const auto& target : targets)
   {

--- a/src/dart_manual.cpp
+++ b/src/dart_manual.cpp
@@ -86,9 +86,9 @@ DartManual::DartManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee) : Manua
 
 void DartManual::run()
 {
-  ManualBase::run();
   trigger_calibration_->update(ros::Time::now());
   gimbal_calibration_->update(ros::Time::now());
+  ManualBase::run();
 }
 
 void DartManual::gameRobotStatusCallback(const rm_msgs::GameRobotStatus::ConstPtr& data)
@@ -182,6 +182,8 @@ void DartManual::checkReferee()
 void DartManual::remoteControlTurnOn()
 {
   ManualBase::remoteControlTurnOn();
+  gimbal_calibration_->stopController();
+  trigger_calibration_->stopController();
   gimbal_calibration_->reset();
   trigger_calibration_->reset();
 }
@@ -333,8 +335,10 @@ void DartManual::recordPosition(const rm_msgs::DbusData dbus_data)
 void DartManual::dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data)
 {
   ManualBase::dbusDataCallback(data);
-  if (remote_is_open_)
+  if (!joint_state_.name.empty())
+  {
     trigger_position_ = std::abs(joint_state_.position[trigger_sender_->getIndex()]);
+  }
   wheel_clockwise_event_.update(data->wheel == 1.0);
   wheel_anticlockwise_event_.update(data->wheel == -1.0);
   dbus_data_ = *data;

--- a/src/dart_manual.cpp
+++ b/src/dart_manual.cpp
@@ -62,14 +62,7 @@ void DartManual::getList(const XmlRpc::XmlRpcValue& darts, const XmlRpc::XmlRpcV
     dart_info.base_offset_ = static_cast<double>(dart.second["param"][2]);
     dart_info.base_qd_ = static_cast<double>(dart.second["param"][3]);
     dart_info.trigger_position_ = static_cast<double>(dart.second["param"][4]);
-    if (dart.first == "first_dart")
-      dart_list_.insert(std::make_pair(0, dart_info));
-    if (dart.first == "second_dart")
-      dart_list_.insert(std::make_pair(1, dart_info));
-    if (dart.first == "third_dart")
-      dart_list_.insert(std::make_pair(2, dart_info));
-    if (dart.first == "fourth_dart")
-      dart_list_.insert(std::make_pair(3, dart_info));
+    dart_list_.insert(std::make_pair(std::stoi(dart.first) - 1, dart_info));
   }
   for (const auto& target : targets)
   {


### PR DESCRIPTION
### 关于Fixed unreasonable overload error
由于在父类中多加了无参数的左拨杆高电平触发函数，导致重载后的chassis_gimbal_shooter_manual中有参数的同名左拨杆高电平触发函数爆红（但是可以通过编译）。为了解决爆红，删除掉父类中的无参数的左拨杆高电平触发函数，并取消dart_manual中的左拨杆高电平触发函数重载。
### 关于optimized the auto mode
先前的自动模式没有考虑到：在比赛开始后、飞镖门完全开启时，若此时前哨站被击破，则会出现飞镖架未移动到基地位置时就再次发射的情况。在本情况的基础上，即使飞镖架移动到基地位置再发射，也可能会出现因**飞镖发射时飞镖门恰好即将关闭**，导致飞镖以基地速度射在正在关闭的飞镖门上。（2023中部赛区对局桂电出现的情况）
本pr解决上述问题的大致方法是：禁止移动中发射；禁止飞镖门开启时，第一次射击前哨站状态切换到射击基地状态时再次发射。
### 将每次飞镖闸门开启后，飞镖发射枚数固定为2
### 每发射一发都暂停一定秒数（秒数依规则改变）
确保不会出现连续击中不计入伤害的情况。
### 修改参数的获取方式
从单个参数记录方式变为二维数组记录方式。