### PR TITLE
Move gimbal calibration related code to ChassisGimablShooterManual

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -12,7 +12,6 @@ class ChassisGimbalShooterCoverManual : public ChassisGimbalShooterManual
 {
 public:
   ChassisGimbalShooterCoverManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee);
-  void run() override;
 
 protected:
   void updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data) override;
@@ -20,14 +19,12 @@ protected:
   void checkReferee() override;
   void sendCommand(const ros::Time& time) override;
   void gimbalOutputOn() override;
-  void remoteControlTurnOff() override;
-  void remoteControlTurnOn() override;
+  void chassisOutputOn() override;
   void rightSwitchDownRise() override;
   void rightSwitchMidRise() override;
   void rightSwitchUpRise() override;
   void rPress() override;
   void ePress() override;
-  void ctrlQPress() override;
   void zPressing();
   void zRelease();
   virtual void ctrlZPress();
@@ -38,7 +35,6 @@ protected:
   rm_common::SwitchDetectionCaller* switch_buff_srv_{};
   rm_common::SwitchDetectionCaller* switch_buff_type_srv_{};
   rm_common::JointPositionBinaryCommandSender* cover_command_sender_{};
-  rm_common::CalibrationQueue* gimbal_calibration_;
   InputEvent ctrl_z_event_, ctrl_q_event_, x_event_, z_event_;
   std::string supply_frame_;
   bool supply_ = false;

--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -18,8 +18,6 @@ protected:
   void checkKeyboard(const rm_msgs::DbusData::ConstPtr& dbus_data) override;
   void checkReferee() override;
   void sendCommand(const ros::Time& time) override;
-  void gimbalOutputOn() override;
-  void chassisOutputOn() override;
   void rightSwitchDownRise() override;
   void rightSwitchMidRise() override;
   void rightSwitchUpRise() override;

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -24,6 +24,7 @@ protected:
   void sendCommand(const ros::Time& time) override;
   void chassisOutputOn() override;
   void shooterOutputOn() override;
+  void gimbalOutputOn() override;
   void selfInspectionStart()
   {
     shooter_calibration_->reset();

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -108,6 +108,7 @@ protected:
   rm_common::SwitchDetectionCaller* switch_detection_srv_{};
   rm_common::SwitchDetectionCaller* switch_armor_target_srv_{};
   rm_common::CalibrationQueue* shooter_calibration_;
+  rm_common::CalibrationQueue* gimbal_calibration_;
 
   geometry_msgs::PointStamped point_out_;
 

--- a/src/chassis_gimbal_shooter_cover_manual.cpp
+++ b/src/chassis_gimbal_shooter_cover_manual.cpp
@@ -96,18 +96,6 @@ void ChassisGimbalShooterCoverManual::sendCommand(const ros::Time& time)
   cover_command_sender_->sendCommand(time);
 }
 
-void ChassisGimbalShooterCoverManual::gimbalOutputOn()
-{
-  ChassisGimbalShooterManual::gimbalOutputOn();
-  gimbal_calibration_->reset();
-}
-
-void ChassisGimbalShooterCoverManual::chassisOutputOn()
-{
-  ChassisGimbalManual::chassisOutputOn();
-  chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
-}
-
 void ChassisGimbalShooterCoverManual::rightSwitchDownRise()
 {
   ChassisGimbalShooterManual::rightSwitchDownRise();

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -21,9 +21,12 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
   ros::NodeHandle armor_target_switch_nh(nh, "armor_target_switch");
   switch_armor_target_srv_ = new rm_common::SwitchDetectionCaller(armor_target_switch_nh);
-  XmlRpc::XmlRpcValue rpc_value;
-  nh.getParam("shooter_calibration", rpc_value);
-  shooter_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
+  XmlRpc::XmlRpcValue rpc_value1;
+  nh.getParam("shooter_calibration", rpc_value1);
+  shooter_calibration_ = new rm_common::CalibrationQueue(rpc_value1, nh, controller_manager_);
+  XmlRpc::XmlRpcValue rpc_value2;
+  nh.getParam("gimbal_calibration", rpc_value2);
+  gimbal_calibration_ = new rm_common::CalibrationQueue(rpc_value2, nh, controller_manager_);
 
   shooter_power_on_event_.setRising(boost::bind(&ChassisGimbalShooterManual::shooterOutputOn, this));
   self_inspection_event_.setRising(boost::bind(&ChassisGimbalShooterManual::selfInspectionStart, this));
@@ -54,6 +57,7 @@ void ChassisGimbalShooterManual::run()
 {
   ChassisGimbalManual::run();
   shooter_calibration_->update(ros::Time::now());
+  gimbal_calibration_->update(ros::Time::now());
 }
 
 void ChassisGimbalShooterManual::checkReferee()
@@ -145,6 +149,7 @@ void ChassisGimbalShooterManual::remoteControlTurnOff()
   ChassisGimbalManual::remoteControlTurnOff();
   shooter_cmd_sender_->setZero();
   shooter_calibration_->stop();
+  gimbal_calibration_->stop();
   turn_flag_ = false;
 }
 
@@ -152,6 +157,7 @@ void ChassisGimbalShooterManual::remoteControlTurnOn()
 {
   ChassisGimbalManual::remoteControlTurnOn();
   shooter_calibration_->stopController();
+  gimbal_calibration_->stopController();
   std::string robot_color = robot_id_ >= 100 ? "blue" : "red";
   switch_detection_srv_->setEnemyColor(robot_id_, robot_color);
 }
@@ -167,6 +173,7 @@ void ChassisGimbalShooterManual::chassisOutputOn()
 {
   ChassisGimbalManual::chassisOutputOn();
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
+  gimbal_calibration_->reset();
 }
 
 void ChassisGimbalShooterManual::shooterOutputOn()
@@ -529,5 +536,6 @@ void ChassisGimbalShooterManual::ctrlBPress()
 void ChassisGimbalShooterManual::ctrlQPress()
 {
   shooter_calibration_->reset();
+  gimbal_calibration_->reset();
 }
 }  // namespace rm_manual

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -21,14 +21,11 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   switch_detection_srv_ = new rm_common::SwitchDetectionCaller(detection_switch_nh);
   ros::NodeHandle armor_target_switch_nh(nh, "armor_target_switch");
   switch_armor_target_srv_ = new rm_common::SwitchDetectionCaller(armor_target_switch_nh);
-  XmlRpc::XmlRpcValue rpc_value1;
-  nh.getParam("shooter_calibration", rpc_value1);
-  shooter_calibration_ = new rm_common::CalibrationQueue(rpc_value1, nh, controller_manager_);
-  XmlRpc::XmlRpcValue rpc_value2;
-  if (nh.getParam("gimbal_calibration", rpc_value2))
-  {
-    gimbal_calibration_ = new rm_common::CalibrationQueue(rpc_value2, nh, controller_manager_);
-  }
+  XmlRpc::XmlRpcValue rpc_value;
+  nh.getParam("shooter_calibration", rpc_value);
+  shooter_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
+  nh.getParam("gimbal_calibration", rpc_value);
+  gimbal_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
   shooter_power_on_event_.setRising(boost::bind(&ChassisGimbalShooterManual::shooterOutputOn, this));
   self_inspection_event_.setRising(boost::bind(&ChassisGimbalShooterManual::selfInspectionStart, this));
   game_start_event_.setRising(boost::bind(&ChassisGimbalShooterManual::gameStart, this));
@@ -58,8 +55,7 @@ void ChassisGimbalShooterManual::run()
 {
   ChassisGimbalManual::run();
   shooter_calibration_->update(ros::Time::now());
-  if (gimbal_calibration_)
-    gimbal_calibration_->update(ros::Time::now());
+  gimbal_calibration_->update(ros::Time::now());
 }
 
 void ChassisGimbalShooterManual::checkReferee()
@@ -151,8 +147,7 @@ void ChassisGimbalShooterManual::remoteControlTurnOff()
   ChassisGimbalManual::remoteControlTurnOff();
   shooter_cmd_sender_->setZero();
   shooter_calibration_->stop();
-  if (gimbal_calibration_)
-    gimbal_calibration_->stop();
+  gimbal_calibration_->stop();
   turn_flag_ = false;
 }
 
@@ -160,8 +155,7 @@ void ChassisGimbalShooterManual::remoteControlTurnOn()
 {
   ChassisGimbalManual::remoteControlTurnOn();
   shooter_calibration_->stopController();
-  if (gimbal_calibration_)
-    gimbal_calibration_->stopController();
+  gimbal_calibration_->stopController();
   std::string robot_color = robot_id_ >= 100 ? "blue" : "red";
   switch_detection_srv_->setEnemyColor(robot_id_, robot_color);
 }
@@ -189,8 +183,7 @@ void ChassisGimbalShooterManual::shooterOutputOn()
 void ChassisGimbalShooterManual::gimbalOutputOn()
 {
   ChassisGimbalManual::gimbalOutputOn();
-  if (gimbal_calibration_)
-    gimbal_calibration_->reset();
+  gimbal_calibration_->reset();
 }
 
 void ChassisGimbalShooterManual::updateRc(const rm_msgs::DbusData::ConstPtr& dbus_data)
@@ -546,7 +539,6 @@ void ChassisGimbalShooterManual::ctrlBPress()
 void ChassisGimbalShooterManual::ctrlQPress()
 {
   shooter_calibration_->reset();
-  if (gimbal_calibration_)
-    gimbal_calibration_->reset();
+  gimbal_calibration_->reset();
 }
 }  // namespace rm_manual

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -177,8 +177,6 @@ void ChassisGimbalShooterManual::chassisOutputOn()
 {
   ChassisGimbalManual::chassisOutputOn();
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
-  if (gimbal_calibration_)
-    gimbal_calibration_->reset();
 }
 
 void ChassisGimbalShooterManual::shooterOutputOn()
@@ -186,6 +184,13 @@ void ChassisGimbalShooterManual::shooterOutputOn()
   ChassisGimbalManual::shooterOutputOn();
   shooter_cmd_sender_->setMode(rm_msgs::ShootCmd::STOP);
   shooter_calibration_->reset();
+}
+
+void ChassisGimbalShooterManual::gimbalOutputOn()
+{
+  ChassisGimbalManual::gimbalOutputOn();
+  if (gimbal_calibration_)
+    gimbal_calibration_->reset();
 }
 
 void ChassisGimbalShooterManual::updateRc(const rm_msgs::DbusData::ConstPtr& dbus_data)

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -75,6 +75,7 @@ void ManualBase::checkReferee()
 {
   gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(2.5));
   shooter_power_on_event_.update((ros::Time::now() - shooter_actuator_last_get_stamp_) < ros::Duration(2.5));
+  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(2.5));
   referee_is_online_ = (ros::Time::now() - referee_last_get_stamp_ < ros::Duration(0.3));
   manual_to_referee_pub_.publish(manual_to_referee_pub_data_);
 }
@@ -106,6 +107,7 @@ void ManualBase::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& d
 {
   updateActuatorStamp(data, gimbal_mount_motor_, gimbal_actuator_last_get_stamp_);
   updateActuatorStamp(data, shooter_mount_motor_, shooter_actuator_last_get_stamp_);
+  updateActuatorStamp(data, chassis_mount_motor_, chassis_actuator_last_get_stamp_);
 }
 
 void ManualBase::dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data)

--- a/src/manual_base.cpp
+++ b/src/manual_base.cpp
@@ -75,7 +75,6 @@ void ManualBase::checkReferee()
 {
   gimbal_power_on_event_.update((ros::Time::now() - gimbal_actuator_last_get_stamp_) < ros::Duration(2.5));
   shooter_power_on_event_.update((ros::Time::now() - shooter_actuator_last_get_stamp_) < ros::Duration(2.5));
-  chassis_power_on_event_.update((ros::Time::now() - chassis_actuator_last_get_stamp_) < ros::Duration(2.5));
   referee_is_online_ = (ros::Time::now() - referee_last_get_stamp_ < ros::Duration(0.3));
   manual_to_referee_pub_.publish(manual_to_referee_pub_data_);
 }
@@ -107,7 +106,6 @@ void ManualBase::actuatorStateCallback(const rm_msgs::ActuatorState::ConstPtr& d
 {
   updateActuatorStamp(data, gimbal_mount_motor_, gimbal_actuator_last_get_stamp_);
   updateActuatorStamp(data, shooter_mount_motor_, shooter_actuator_last_get_stamp_);
-  updateActuatorStamp(data, chassis_mount_motor_, chassis_actuator_last_get_stamp_);
 }
 
 void ManualBase::dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data)


### PR DESCRIPTION
1. 由于轻量化英雄需要云台校准，所以将gimbal calibration相关代码移动到ChassisGimablShooterManual中
2. 由于英雄云台没有接电源管理gimbal，而是通过电子开关由Chassis控制上电，因此在ChassisOutOn中调用gimbal_calibration_->reset()，即校准云台，在ChassisGimablShooterCoverManual中重写ChassisOutOn.