### PR TITLE
Engineer manual except auto_exchange and ui.

### DIFF
--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -129,7 +129,6 @@ private:
 
   void mouseLeftRelease();
   void mouseRightRelease();
-  void exchangeCallback(const rm_msgs::ExchangerMsg::ConstPtr& data);
   void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
   void stoneNumCallback(const std_msgs::String ::ConstPtr& data);
 
@@ -140,12 +139,8 @@ private:
   double gyro_scale_{}, fast_gyro_scale_{}, normal_gyro_scale_{}, low_gyro_scale_{}, exchange_gyro_scale_{};
   std::string prefix_{}, root_{}, drag_state_{ "on" }, max_temperature_joint_{}, joint_temperature_{},
       reversal_state_{}, gripper_state_{};
-  geometry_msgs::TransformStamped base2yaw_{}, yaw2pitch_{}, exchange2base_{}, link22base_{}, link32base_{},
-      exchange2stone_{};
-  geometry_msgs::PoseStamped chassis_target_{}, chassis_original_target_{};
 
-  ros::Publisher engineer_ui_pub_;
-  ros::Subscriber exchange_sub_, gripper_state_sub_, stone_num_sub_;
+  ros::Subscriber gripper_state_sub_, stone_num_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
 
   rm_msgs::EngineerUi engineer_ui_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -130,7 +130,7 @@ private:
   void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
   void stoneNumCallback(const std_msgs::String ::ConstPtr& data);
 
-  bool reversal_motion_{}, change_flag_{};
+  bool reversal_motion_{}, motion_change_flag_{};
   int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{};
   double angular_z_scale_{};
   double fast_speed_scale_{}, normal_speed_scale_{}, low_speed_scale_{}, exchange_speed_scale_{};
@@ -146,7 +146,7 @@ private:
   rm_common::MultiDofCommandSender* reversal_command_sender_;
   rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;
   rm_common::JointPositionBinaryCommandSender *drag_command_sender_, *joint7_command_sender_;
-  rm_common::CalibrationQueue *calibration_gather_{}, *joint5_calibration_{};
+  rm_common::CalibrationQueue* calibration_gather_{};
   InputEvent left_switch_up_event_, left_switch_down_event_, ctrl_q_event_, ctrl_a_event_, ctrl_z_event_, ctrl_w_event_,
       ctrl_s_event_, ctrl_x_event_, ctrl_e_event_, ctrl_d_event_, ctrl_c_event_, ctrl_b_event_, ctrl_v_event_, z_event_,
       q_event_, e_event_, x_event_, c_event_, v_event_, b_event_, f_event_, shift_z_event_, shift_x_event_,

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -141,7 +141,6 @@ private:
   ros::Subscriber gripper_state_sub_, stone_num_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
 
-  rm_msgs::EngineerUi engineer_ui_;
   rm_msgs::GpioData gpio_state_;
   rm_common::Vel3DCommandSender* servo_command_sender_;
   rm_common::MultiDofCommandSender* reversal_command_sender_;

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -13,8 +13,6 @@
 #include <std_msgs/Float64.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <rm_msgs/EngineerAction.h>
-#include <rm_msgs/EngineerUi.h>
-#include <rm_msgs/ExchangerMsg.h>
 #include <rm_msgs/MultiDofCmd.h>
 #include <rm_msgs/GpioData.h>
 #include <angles/angles.h>

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -15,6 +15,7 @@
 #include <rm_msgs/EngineerAction.h>
 #include <rm_msgs/MultiDofCmd.h>
 #include <rm_msgs/GpioData.h>
+#include <angles/angles.h>
 
 namespace rm_manual
 {

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -14,6 +14,10 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <rm_msgs/EngineerAction.h>
 #include <rm_msgs/EngineerUi.h>
+#include <rm_msgs/ExchangerMsg.h>
+#include <rm_msgs/MultiDofCmd.h>
+#include <rm_msgs/GpioData.h>
+#include <angles/angles.h>
 
 namespace rm_manual
 {
@@ -60,8 +64,7 @@ private:
   void actionFeedbackCallback(const rm_msgs::EngineerFeedbackConstPtr& feedback);
   void actionDoneCallback(const actionlib::SimpleClientGoalState& state, const rm_msgs::EngineerResultConstPtr& result);
   void runStepQueue(const std::string& step_queue_name);
-  void judgePrefix();
-  void judgeRoot();
+  void initMode();
   void actionActiveCallback()
   {
     operating_mode_ = MIDDLEWARE;
@@ -74,12 +77,15 @@ private:
   void leftSwitchUpRise() override;
   void leftSwitchUpFall();
   void leftSwitchDownFall();
+  void leftSwitchDownRise() override;
   void ctrlQPress();
   void ctrlWPress();
   void ctrlEPress();
   void ctrlAPress();
   void ctrlSPress();
   void ctrlZPress();
+  void ctrlZPressing();
+  void ctrlZRelease();
   void ctrlXPress();
   void ctrlCPress();
   void ctrlDPress();
@@ -97,9 +103,11 @@ private:
   void shiftBPress();
   void shiftBRelease();
   void shiftGPress();
-  void shiftRPress();
+  void shiftRPressing();
+  void shiftRRelease();
   void shiftVPress();
   void shiftVRelease();
+  void shiftFPress();
   void rPress();
   void qPressing();
   void qRelease();
@@ -114,37 +122,44 @@ private:
   void bRelease();
   void vPressing();
   void vRelease();
-  void fPressing();
+  void fPress();
   void fRelease();
-  void gPressing();
+  void gPress();
   void gRelease();
 
   void mouseLeftRelease();
   void mouseRightRelease();
+  void exchangeCallback(const rm_msgs::ExchangerMsg::ConstPtr& data);
+  void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
+  void stoneNumCallback(const std_msgs::String ::ConstPtr& data);
 
-  int state_;
-  rm_msgs::EngineerUi engineer_ui_;
-  double angular_z_scale_{}, gyro_scale_{}, fast_gyro_scale_{}, low_gyro_scale_{}, normal_gyro_scale_{},
-      exchange_gyro_scale_{}, fast_speed_scale_{}, low_speed_scale_{}, normal_speed_scale_{}, exchange_speed_scale_{};
-  ;
-  std::string prefix_, root_, reversal_state_;
-  int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{}, gripper_state_{}, drag_state_{};
-  std::map<std::string, int> prefix_list_, root_list_;
+  bool reversal_motion_{}, change_flag_{};
+  int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{};
+  double angular_z_scale_{};
+  double fast_speed_scale_{}, normal_speed_scale_{}, low_speed_scale_{}, exchange_speed_scale_{};
+  double gyro_scale_{}, fast_gyro_scale_{}, normal_gyro_scale_{}, low_gyro_scale_{}, exchange_gyro_scale_{};
+  std::string prefix_{}, root_{}, drag_state_{ "on" }, max_temperature_joint_{}, joint_temperature_{},
+      reversal_state_{}, gripper_state_{};
+  geometry_msgs::TransformStamped base2yaw_{}, yaw2pitch_{}, exchange2base_{}, link22base_{}, link32base_{},
+      exchange2stone_{};
+  geometry_msgs::PoseStamped chassis_target_{}, chassis_original_target_{};
 
-  ros::Time last_time_;
-  ros::Subscriber reversal_vision_sub_;
   ros::Publisher engineer_ui_pub_;
-
+  ros::Subscriber exchange_sub_, gripper_state_sub_, stone_num_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;
-  rm_common::CalibrationQueue *power_on_calibration_{}, *arm_calibration_{};
+
+  rm_msgs::EngineerUi engineer_ui_;
+  rm_msgs::GpioData gpio_state_;
   rm_common::Vel3DCommandSender* servo_command_sender_;
+  rm_common::MultiDofCommandSender* reversal_command_sender_;
   rm_common::ServiceCallerBase<std_srvs::Empty>* servo_reset_caller_;
+  rm_common::JointPositionBinaryCommandSender *drag_command_sender_, *joint7_command_sender_;
+  rm_common::CalibrationQueue *calibration_gather_{}, *joint5_calibration_{};
   InputEvent left_switch_up_event_, left_switch_down_event_, ctrl_q_event_, ctrl_a_event_, ctrl_z_event_, ctrl_w_event_,
       ctrl_s_event_, ctrl_x_event_, ctrl_e_event_, ctrl_d_event_, ctrl_c_event_, ctrl_b_event_, ctrl_v_event_, z_event_,
       q_event_, e_event_, x_event_, c_event_, v_event_, b_event_, f_event_, shift_z_event_, shift_x_event_,
-      shift_c_event_, shift_v_event_, shift_b_event_, shift_g_event_, ctrl_r_event_, shift_q_event_, shift_e_event_,
-      ctrl_g_event_, shift_r_event_, ctrl_f_event_, shift_event_, g_event_, r_event_, mouse_left_event_,
+      shift_c_event_, shift_v_event_, shift_b_event_, shift_g_event_, ctrl_r_event_, shift_q_event_, shift_f_event_,
+      shift_e_event_, ctrl_g_event_, shift_r_event_, ctrl_f_event_, shift_event_, g_event_, r_event_, mouse_left_event_,
       mouse_right_event_;
 };
-
 }  // namespace rm_manual

--- a/include/rm_manual/engineer_manual.h
+++ b/include/rm_manual/engineer_manual.h
@@ -15,7 +15,6 @@
 #include <rm_msgs/EngineerAction.h>
 #include <rm_msgs/MultiDofCmd.h>
 #include <rm_msgs/GpioData.h>
-#include <angles/angles.h>
 
 namespace rm_manual
 {
@@ -130,13 +129,12 @@ private:
   void gpioStateCallback(const rm_msgs::GpioData::ConstPtr& data);
   void stoneNumCallback(const std_msgs::String ::ConstPtr& data);
 
-  bool reversal_motion_{}, motion_change_flag_{};
+  bool motion_change_flag_{};
   int operating_mode_{}, servo_mode_{}, gimbal_mode_{}, stone_num_{};
-  double angular_z_scale_{};
-  double fast_speed_scale_{}, normal_speed_scale_{}, low_speed_scale_{}, exchange_speed_scale_{};
-  double gyro_scale_{}, fast_gyro_scale_{}, normal_gyro_scale_{}, low_gyro_scale_{}, exchange_gyro_scale_{};
-  std::string prefix_{}, root_{}, drag_state_{ "on" }, max_temperature_joint_{}, joint_temperature_{},
-      reversal_state_{}, gripper_state_{};
+  double angular_z_scale_{}, angular_z_max_scale_{}, fast_speed_scale_{}, normal_speed_scale_{}, low_speed_scale_{},
+      exchange_speed_scale_{}, gyro_scale_{}, fast_gyro_scale_{}, normal_gyro_scale_{}, low_gyro_scale_{},
+      exchange_gyro_scale_{};
+  std::string prefix_{}, root_{}, drag_state_{ "on" }, reversal_state_{}, gripper_state_{};
 
   ros::Subscriber gripper_state_sub_, stone_num_sub_;
   actionlib::SimpleActionClient<rm_msgs::EngineerAction> action_client_;

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -111,6 +111,30 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   mouse_right_event_.setFalling(boost::bind(&EngineerManual::mouseRightRelease, this));
 }
 
+void EngineerManual::changeSpeedMode(SpeedMode speed_mode)
+{
+  if (speed_mode == LOW)
+  {
+    speed_change_scale_ = low_speed_scale_;
+    gyro_scale_ = low_gyro_scale_;
+  }
+  else if (speed_mode == NORMAL)
+  {
+    speed_change_scale_ = normal_speed_scale_;
+    gyro_scale_ = normal_gyro_scale_;
+  }
+  else if (speed_mode == FAST)
+  {
+    speed_change_scale_ = fast_speed_scale_;
+    gyro_scale_ = fast_gyro_scale_;
+  }
+  else if (speed_mode == EXCHANGE)
+  {
+    speed_change_scale_ = exchange_speed_scale_;
+    gyro_scale_ = exchange_gyro_scale_;
+  }
+}
+
 void EngineerManual::run()
 {
   ChassisGimbalManual::run();
@@ -197,30 +221,6 @@ void EngineerManual::gpioStateCallback(const rm_msgs::GpioData ::ConstPtr& data)
     gripper_state_ = "close";
 }
 
-void EngineerManual::changeSpeedMode(SpeedMode speed_mode)
-{
-  if (speed_mode == LOW)
-  {
-    speed_change_scale_ = low_speed_scale_;
-    gyro_scale_ = low_gyro_scale_;
-  }
-  else if (speed_mode == NORMAL)
-  {
-    speed_change_scale_ = normal_speed_scale_;
-    gyro_scale_ = normal_gyro_scale_;
-  }
-  else if (speed_mode == FAST)
-  {
-    speed_change_scale_ = fast_speed_scale_;
-    gyro_scale_ = fast_gyro_scale_;
-  }
-  else if (speed_mode == EXCHANGE)
-  {
-    speed_change_scale_ = exchange_speed_scale_;
-    gyro_scale_ = exchange_gyro_scale_;
-  }
-}
-
 void EngineerManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
 {
   ChassisGimbalManual::updatePc(dbus_data);
@@ -264,8 +264,8 @@ void EngineerManual::remoteControlTurnOff()
 
 void EngineerManual::chassisOutputOn()
 {
-  //  if (operating_mode_ == MIDDLEWARE)
-  //    action_client_.cancelAllGoals();
+  if (operating_mode_ == MIDDLEWARE)
+    action_client_.cancelAllGoals();
 }
 
 void EngineerManual::rightSwitchDownRise()

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -221,6 +221,16 @@ void EngineerManual::gpioStateCallback(const rm_msgs::GpioData ::ConstPtr& data)
     gripper_state_ = "close";
 }
 
+void EngineerManual::updateRc(const rm_msgs::DbusData::ConstPtr& dbus_data)
+{
+  ChassisGimbalManual::updateRc(dbus_data);
+  chassis_cmd_sender_->setMode(rm_msgs::ChassisCmd::RAW);
+  chassis_cmd_sender_->getMsg()->command_source_frame = "base_link";
+  vel_cmd_sender_->setAngularZVel(dbus_data->wheel);
+  left_switch_up_event_.update(dbus_data->s_l == rm_msgs::DbusData::UP);
+  left_switch_down_event_.update(dbus_data->s_l == rm_msgs::DbusData::DOWN);
+}
+
 void EngineerManual::updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data)
 {
   ChassisGimbalManual::updatePc(dbus_data);

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -613,7 +613,6 @@ void EngineerManual::gPress()
 {
   // PITCH
   runStepQueue("PITCH_PI_2");
-  // reversal_command_sender_->setGroupVel(0., 0., -0.3, 0., 1.5, 0.);
   reversal_state_ = "PITCH";
 }
 

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -724,6 +724,14 @@ void EngineerManual::shiftBRelease()
 {
 }
 
+void EngineerManual::shiftRRelease()
+{
+}
+
+void EngineerManual::shiftRPressing()
+{
+}
+
 void EngineerManual::shiftXPress()
 {
   runStepQueue("GROUND_GIMBAL");

--- a/src/engineer_manual.cpp
+++ b/src/engineer_manual.cpp
@@ -53,8 +53,6 @@ EngineerManual::EngineerManual(ros::NodeHandle& nh, ros::NodeHandle& nh_referee)
   XmlRpc::XmlRpcValue rpc_value;
   nh.getParam("calibration_gather", rpc_value);
   calibration_gather_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
-  nh.getParam("joint5_calibration", rpc_value);
-  joint5_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
 
   left_switch_up_event_.setFalling(boost::bind(&EngineerManual::leftSwitchUpFall, this));
   left_switch_up_event_.setRising(boost::bind(&EngineerManual::leftSwitchUpRise, this));
@@ -316,7 +314,6 @@ void EngineerManual::leftSwitchDownFall()
 
 void EngineerManual::leftSwitchUpFall()
 {
-  joint5_calibration_->reset();
 }
 
 void EngineerManual::leftSwitchDownRise()
@@ -351,7 +348,7 @@ void EngineerManual::actionDoneCallback(const actionlib::SimpleClientGoalState& 
   ROS_INFO("Result: %i", result->finish);
   ROS_INFO("Done %s", (prefix_ + root_).c_str());
   reversal_motion_ = false;
-  change_flag_ = true;
+  motion_change_flag_ = true;
   if (prefix_ + root_ == "TWO_STONE_SMALL_ISLAND0")
     changeSpeedMode(LOW);
   ROS_INFO("%i", result->finish);
@@ -360,10 +357,10 @@ void EngineerManual::actionDoneCallback(const actionlib::SimpleClientGoalState& 
 
 void EngineerManual::mouseLeftRelease()
 {
-  if (change_flag_)
+  if (motion_change_flag_)
   {
     root_ += "0";
-    change_flag_ = false;
+    motion_change_flag_ = false;
     runStepQueue(prefix_ + root_);
     ROS_INFO("Finished %s", (prefix_ + root_).c_str());
   }
@@ -407,7 +404,6 @@ void EngineerManual::ctrlRPress()
   root_ = "CALIBRATION";
   servo_mode_ = JOINT;
   calibration_gather_->reset();
-  joint5_calibration_->reset();
   runStepQueue("CLOSE_GRIPPER");
   ROS_INFO_STREAM("START CALIBRATE");
 }


### PR DESCRIPTION
### pr内容
- 更新了按键功能
- 加入了翻转控制
- 加入了矿石数量和气泵状态的suscribe，用于实时更新

#### 说明
- 自动兑换的内容没在这次pr内
- ui的内容没在这次pr内
- 矿石数量suscribe是因为矿石数量更改在middleware中
- 气泵状态的suscribe是因为middleware和manual都可以对气泵进行控制。