### PR TITLE
Use actor halted in motor calibrate.

### DIFF
--- a/include/rm_manual/manual_base.h
+++ b/include/rm_manual/manual_base.h
@@ -57,8 +57,8 @@ protected:
   virtual void updateRc(const rm_msgs::DbusData::ConstPtr& dbus_data);
   virtual void updatePc(const rm_msgs::DbusData::ConstPtr& dbus_data);
   virtual void sendCommand(const ros::Time& time) = 0;
-  virtual void updateActuatorStamp(const rm_msgs::ActuatorState::ConstPtr& data, std::vector<std::string> act_vector,
-                                   ros::Time& last_get_stamp);
+  virtual void updateActuatorHalted(const rm_msgs::ActuatorState::ConstPtr& data, std::vector<std::string> act_vector,
+                                    int& halted);
 
   virtual void jointStateCallback(const sensor_msgs::JointState::ConstPtr& data);
   virtual void dbusDataCallback(const rm_msgs::DbusData::ConstPtr& data);
@@ -161,7 +161,7 @@ protected:
       left_switch_down_event_, left_switch_mid_event_, left_switch_up_event_;
 
   InputEvent chassis_power_on_event_, gimbal_power_on_event_, shooter_power_on_event_;
-  ros::Time chassis_actuator_last_get_stamp_, gimbal_actuator_last_get_stamp_, shooter_actuator_last_get_stamp_;
+  int chassis_actuator_halted_ = 1, gimbal_actuator_halted_ = 1, shooter_actuator_halted_ = 1;
   std::vector<std::string> chassis_mount_motor_, gimbal_mount_motor_, shooter_mount_motor_;
 };
 

--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -23,8 +23,8 @@ ChassisGimbalManual::ChassisGimbalManual(ros::NodeHandle& nh, ros::NodeHandle& n
   if (!gimbal_nh.getParam("finish_turning_threshold", finish_turning_threshold_))
     ROS_ERROR("Finish turning threshold no defined (namespace: %s)", nh.getNamespace().c_str());
 
-  chassis_power_on_event_.setRising(boost::bind(&ChassisGimbalManual::chassisOutputOn, this));
-  gimbal_power_on_event_.setRising(boost::bind(&ChassisGimbalManual::gimbalOutputOn, this));
+  chassis_power_on_event_.setFalling(boost::bind(&ChassisGimbalManual::chassisOutputOn, this));
+  gimbal_power_on_event_.setFalling(boost::bind(&ChassisGimbalManual::gimbalOutputOn, this));
   w_event_.setEdge(boost::bind(&ChassisGimbalManual::wPress, this), boost::bind(&ChassisGimbalManual::wRelease, this));
   w_event_.setActiveHigh(boost::bind(&ChassisGimbalManual::wPressing, this));
   s_event_.setEdge(boost::bind(&ChassisGimbalManual::sPress, this), boost::bind(&ChassisGimbalManual::sRelease, this));

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -36,7 +36,7 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   shooter_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
   nh.getParam("gimbal_calibration", rpc_value);
   gimbal_calibration_ = new rm_common::CalibrationQueue(rpc_value, nh, controller_manager_);
-  shooter_power_on_event_.setRising(boost::bind(&ChassisGimbalShooterManual::shooterOutputOn, this));
+  shooter_power_on_event_.setFalling(boost::bind(&ChassisGimbalShooterManual::shooterOutputOn, this));
   self_inspection_event_.setRising(boost::bind(&ChassisGimbalShooterManual::selfInspectionStart, this));
   game_start_event_.setRising(boost::bind(&ChassisGimbalShooterManual::gameStart, this));
   left_switch_up_event_.setActiveHigh(boost::bind(&ChassisGimbalShooterManual::leftSwitchUpOn, this, _1));


### PR DESCRIPTION
原来的电机校准条件是判断是否数据超时，现在将校准的判断条件改为判断电机的halted数据。
同时为了解决平衡步兵的控制器在没有上电时启动会导致计算出错的情况，在开dbus后触发startMainController()前先判断是否是上电状态，如果不是则等待。