### PR TITLE
MOdify gimbal_scale threshold to avoid pitch_vel and yaw_vel 's value to be zero

### DIFF
--- a/src/chassis_gimbal_manual.cpp
+++ b/src/chassis_gimbal_manual.cpp
@@ -205,12 +205,12 @@ void ChassisGimbalManual::dRelease()
 
 void ChassisGimbalManual::mouseMidRise(double m_z)
 {
-  if (gimbal_scale_ >= 0. && gimbal_scale_ <= 30.)
+  if (gimbal_scale_ >= 1. && gimbal_scale_ <= 30.)
   {
-    if (gimbal_scale_ + 2. <= 30. && m_z > 0.)
-      gimbal_scale_ += 2.;
-    else if (gimbal_scale_ - 2. >= 0. && m_z < 0.)
-      gimbal_scale_ -= 2.;
+    if (gimbal_scale_ + 1. <= 30. && m_z > 0.)
+      gimbal_scale_ += 1.;
+    else if (gimbal_scale_ - 1. >= 0. && m_z < 0.)
+      gimbal_scale_ -= 1.;
   }
 }
 


### PR DESCRIPTION
修改了gimbal_scale 的阈值 防止pitch 和yaw的速度变为0.