### PR TITLE
Avoid capacity keep in charge mode when chassis rotate.

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -83,6 +83,7 @@ protected:
   virtual void eRelease();
   virtual void cPress();
   virtual void bPress();
+  virtual void bRelease();
   virtual void rPress();
   virtual void xReleasing();
   virtual void shiftPress();

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -47,7 +47,8 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   q_event_.setEdge(boost::bind(&ChassisGimbalShooterManual::qPress, this),
                    boost::bind(&ChassisGimbalShooterManual::qRelease, this));
   f_event_.setRising(boost::bind(&ChassisGimbalShooterManual::fPress, this));
-  b_event_.setRising(boost::bind(&ChassisGimbalShooterManual::bPress, this));
+  b_event_.setEdge(boost::bind(&ChassisGimbalShooterManual::bPress, this),
+                   boost::bind(&ChassisGimbalShooterManual::bRelease, this));
   x_event_.setRising(boost::bind(&ChassisGimbalShooterManual::xPress, this));
   x_event_.setActiveLow(boost::bind(&ChassisGimbalShooterManual::xReleasing, this));
   r_event_.setRising(boost::bind(&ChassisGimbalShooterManual::rPress, this));
@@ -397,6 +398,11 @@ void ChassisGimbalShooterManual::cPress()
 void ChassisGimbalShooterManual::bPress()
 {
   chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::CHARGE);
+}
+
+void ChassisGimbalShooterManual::bRelease()
+{
+  chassis_cmd_sender_->power_limit_->updateState(rm_common::PowerLimit::NORMAL);
 }
 
 void ChassisGimbalShooterManual::rPress()


### PR DESCRIPTION
小陀螺时不小心按下b，会导致超电进入充电模式，减慢陀螺转速，现在修改为按下b充超电，放开b会变成normal。