### PR TITLE
Delete unused event.

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_cover_manual.h
@@ -56,7 +56,7 @@ protected:
   rm_common::SwitchDetectionCaller* switch_buff_type_srv_{};
   rm_common::SwitchDetectionCaller* switch_exposure_srv_{};
   rm_common::JointPositionBinaryCommandSender* cover_command_sender_{};
-  InputEvent ctrl_z_event_, ctrl_q_event_, x_event_, z_event_;
+  InputEvent ctrl_z_event_, z_event_;
   std::string supply_frame_;
   ros::Time last_switch_time_;
   bool supply_ = false;


### PR DESCRIPTION
删除一些没用到以及与基类重复的event，防止后面继承父类的子类无法调用。