### PR TITLE
Achieved the function of adjusting the position of image transmission

### DIFF
--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -129,7 +129,7 @@ protected:
   uint8_t last_shoot_freq_{};
 
   bool prepare_shoot_ = false, is_balance_ = false, use_scope_ = false, adjust_image_transmission_ = false,
-       up_change_position_ = false, low_change_position = false, need_change_position = false;
+      up_change_position_ = false, low_change_position_ = false, need_change_position_ = false;
   double yaw_current_{};
   double scale_;
 };

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -129,7 +129,7 @@ protected:
   uint8_t last_shoot_freq_{};
 
   bool prepare_shoot_ = false, is_balance_ = false, use_scope_ = false, adjust_image_transmission_ = false,
-      up_change_position_ = false, low_change_position_ = false, need_change_position_ = false;
+       up_change_position_ = false, low_change_position_ = false, need_change_position_ = false;
   double yaw_current_{};
   double scale_;
 };

--- a/include/rm_manual/chassis_gimbal_shooter_manual.h
+++ b/include/rm_manual/chassis_gimbal_shooter_manual.h
@@ -107,12 +107,14 @@ protected:
   void ctrlVPress();
   void ctrlBPress();
   void ctrlRPress();
+  void ctrlZPress();
+  void ctrlXPress();
   virtual void ctrlRRelease();
   virtual void ctrlQPress();
 
   InputEvent self_inspection_event_, game_start_event_, e_event_, c_event_, g_event_, q_event_, b_event_, x_event_,
-      r_event_, v_event_, ctrl_f_event_, ctrl_v_event_, ctrl_b_event_, ctrl_q_event_, ctrl_r_event_, shift_event_,
-      ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
+      r_event_, v_event_, ctrl_f_event_, ctrl_v_event_, ctrl_b_event_, ctrl_q_event_, ctrl_r_event_, ctrl_z_event_,
+      ctrl_x_event_, shift_event_, ctrl_shift_b_event_, mouse_left_event_, mouse_right_event_;
   rm_common::ShooterCommandSender* shooter_cmd_sender_{};
   rm_common::CameraSwitchCommandSender* camera_switch_cmd_sender_{};
   rm_common::JointPositionBinaryCommandSender* scope_cmd_sender_{};
@@ -126,7 +128,9 @@ protected:
   geometry_msgs::PointStamped point_out_;
   uint8_t last_shoot_freq_{};
 
-  bool prepare_shoot_ = false, is_balance_ = false, use_scope_ = false, adjust_image_transmission_ = false;
+  bool prepare_shoot_ = false, is_balance_ = false, use_scope_ = false, adjust_image_transmission_ = false,
+       up_change_position_ = false, low_change_position = false, need_change_position = false;
   double yaw_current_{};
+  double scale_;
 };
 }  // namespace rm_manual

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -191,7 +191,8 @@ void ChassisGimbalShooterManual::sendCommand(const ros::Time& time)
   }
   if (image_transmission_cmd_sender_)
   {
-    if (!need_change_position_) {
+    if (!need_change_position_)
+    {
       if (!adjust_image_transmission_)
         image_transmission_cmd_sender_->off();
       else
@@ -201,7 +202,9 @@ void ChassisGimbalShooterManual::sendCommand(const ros::Time& time)
     {
       image_transmission_cmd_sender_->changePosition(scale_);
       up_change_position_ = false;
-    } else if (low_change_position_) {
+    }
+    else if (low_change_position_)
+    {
       image_transmission_cmd_sender_->changePosition(-scale_);
       low_change_position_ = false;
     }

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -191,8 +191,7 @@ void ChassisGimbalShooterManual::sendCommand(const ros::Time& time)
   }
   if (image_transmission_cmd_sender_)
   {
-    if (!need_change_position)
-    {
+    if (!need_change_position_) {
       if (!adjust_image_transmission_)
         image_transmission_cmd_sender_->off();
       else
@@ -202,11 +201,9 @@ void ChassisGimbalShooterManual::sendCommand(const ros::Time& time)
     {
       image_transmission_cmd_sender_->changePosition(scale_);
       up_change_position_ = false;
-    }
-    else if (low_change_position)
-    {
+    } else if (low_change_position_) {
       image_transmission_cmd_sender_->changePosition(-scale_);
-      low_change_position = false;
+      low_change_position_ = false;
     }
     image_transmission_cmd_sender_->sendCommand(time);
   }
@@ -222,8 +219,8 @@ void ChassisGimbalShooterManual::remoteControlTurnOff()
   use_scope_ = false;
   adjust_image_transmission_ = false;
   up_change_position_ = false;
-  low_change_position = false;
-  need_change_position = false;
+  low_change_position_ = false;
+  need_change_position_ = false;
 }
 
 void ChassisGimbalShooterManual::remoteControlTurnOn()
@@ -243,8 +240,8 @@ void ChassisGimbalShooterManual::robotDie()
   use_scope_ = false;
   adjust_image_transmission_ = false;
   up_change_position_ = false;
-  low_change_position = false;
-  need_change_position = false;
+  low_change_position_ = false;
+  need_change_position_ = false;
 }
 
 void ChassisGimbalShooterManual::chassisOutputOn()
@@ -655,20 +652,20 @@ void ChassisGimbalShooterManual::ctrlQPress()
   shooter_calibration_->reset();
   gimbal_calibration_->reset();
   up_change_position_ = false;
-  low_change_position = false;
-  need_change_position = false;
+  low_change_position_ = false;
+  need_change_position_ = false;
 }
 
 void ChassisGimbalShooterManual::ctrlZPress()
 {
   up_change_position_ = true;
-  need_change_position = true;
+  need_change_position_ = true;
 }
 
 void ChassisGimbalShooterManual::ctrlXPress()
 {
-  low_change_position = true;
-  need_change_position = true;
+  low_change_position_ = true;
+  need_change_position_ = true;
 }
 
 void ChassisGimbalShooterManual::robotRevive()

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -25,7 +25,7 @@ ChassisGimbalShooterManual::ChassisGimbalShooterManual(ros::NodeHandle& nh, ros:
   {
     ros::NodeHandle image_transmission_nh(nh, "image_transmission");
     image_transmission_cmd_sender_ = new rm_common::JointPositionBinaryCommandSender(image_transmission_nh);
-    scale_ = getParam(image_transmission_nh,"position_scale",1);
+    scale_ = getParam(image_transmission_nh, "position_scale", 1);
   }
 
   ros::NodeHandle detection_switch_nh(nh, "detection_switch");

--- a/src/chassis_gimbal_shooter_manual.cpp
+++ b/src/chassis_gimbal_shooter_manual.cpp
@@ -654,6 +654,9 @@ void ChassisGimbalShooterManual::ctrlQPress()
 {
   shooter_calibration_->reset();
   gimbal_calibration_->reset();
+  up_change_position_ = false;
+  low_change_position = false;
+  need_change_position = false;
 }
 
 void ChassisGimbalShooterManual::ctrlZPress()


### PR DESCRIPTION
实现了英雄机器人可以通过按下ctrl+z、ctrl+x来进行图传位置的上下微调，可以按下ctrl+q来恢复默认吊射图传角度。